### PR TITLE
Solves crash issue, due to missing cursor check.

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/adapters/InstanceAdapter.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/adapters/InstanceAdapter.java
@@ -64,7 +64,10 @@ public class InstanceAdapter extends RecyclerView.Adapter<InstanceAdapter.Instan
 
     @Override
     public int getItemCount() {
-        return cursor.getCount();
+        if (!cursor.isClosed()) {
+            return cursor.getCount();
+        }
+        return 0;
     }
 
 

--- a/skunkworks_crow/src/main/java/org/odk/share/adapters/InstanceAdapter.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/adapters/InstanceAdapter.java
@@ -64,10 +64,7 @@ public class InstanceAdapter extends RecyclerView.Adapter<InstanceAdapter.Instan
 
     @Override
     public int getItemCount() {
-        if (!cursor.isClosed()) {
-            return cursor.getCount();
-        }
-        return 0;
+        return !cursor.isClosed() ? cursor.getCount() : 0;
     }
 
 


### PR DESCRIPTION
Closes #111

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
Verified in physical device Realme U1, Android 8.1.

#### Why is this the best possible solution? Were any other approaches considered?
Unchecked direct access to cursor was causing StaleDataException. Adding cursor-close-check solves this.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).