### PR TITLE
Udated the RX java2 dependencies

### DIFF
--- a/skunkworks_crow/build.gradle
+++ b/skunkworks_crow/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     annotationProcessor "com.google.dagger:dagger-android-processor:${rootProject.daggerVersion}"
 
     // Rx Java 2
-    implementation 'io.reactivex.rxjava2:rxjava:2.1.13'
-    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.7'
 
     // Better "Subjects" for Rx:
     implementation "com.jakewharton.rxrelay2:rxrelay:2.0.0"


### PR DESCRIPTION
Closes #159 
## Description
updated to RXjava 2.2.7
tested in the android studio and no new warnings are given and I also transferred files using my phone no issues I get

## Solution find here 
according to new releases [RXjava](https://github.com/ReactiveX/RxJava/releases) from 2.0.2 to 2.2.7 
I updated the dependencies and Rxandroid also

## Use of updating
This specification itself has evolved out of RxJava 1.x and provides a common baseline for reactive systems and new libraries.
it follows the Reactive-Streams architecture and New primitive types aslo