### PR TITLE
Add Up Button In Activities For Better Navigation

### DIFF
--- a/skunkworks_crow/src/main/AndroidManifest.xml
+++ b/skunkworks_crow/src/main/AndroidManifest.xml
@@ -33,11 +33,23 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".activities.WifiActivity" />
+
+        <activity android:name=".activities.WifiActivity"
+                  android:parentActivityName=".activities.MainActivity">
+            <meta-data
+                    android:name="android.support.PARENT_ACTIVITY"
+                    android:value=".activities.MainActivity"/>
+        </activity>
         <activity android:name=".activities.InstancesList" />
         <activity android:name=".preferences.SettingsPreference" />
         <activity android:name=".activities.WebViewActivity" />
-        <activity android:name=".activities.AboutActivity" />
+
+        <activity android:name=".activities.AboutActivity"
+                  android:parentActivityName=".activities.MainActivity">
+            <meta-data
+                    android:name="android.support.PARENT_ACTIVITY"
+                    android:value=".activities.MainActivity"/>
+        </activity>
         <activity
             android:name=".activities.SendActivity"
             android:configChanges="orientation|screenSize" />
@@ -49,7 +61,14 @@
             android:screenOrientation="portrait"
             android:stateNotNeeded="true"
             tools:replace="android:screenOrientation" />
-        <activity android:name=".activities.InstanceManagerTabs" />
+
+        <activity android:name=".activities.InstanceManagerTabs"
+                  android:parentActivityName=".activities.MainActivity">
+            <meta-data
+                    android:name="android.support.PARENT_ACTIVITY"
+                    android:value=".activities.MainActivity"/>
+        </activity>
+
         <activity android:name=".activities.ReviewFormActivity" />
 
         <provider
@@ -59,7 +78,13 @@
             android:name=".provider.InstanceMapProvider"
             android:authorities="org.odk.share.provider.odk.map" />
 
-        <activity android:name=".activities.SendFormsActivity"></activity>
+        <activity android:name=".activities.SendFormsActivity"
+                  android:parentActivityName=".activities.MainActivity">
+            <meta-data
+                    android:name="android.support.PARENT_ACTIVITY"
+                    android:value=".activities.MainActivity"/>
+        </activity>
+
     </application>
 
 </manifest>

--- a/skunkworks_crow/src/main/java/org/odk/share/activities/AboutActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/activities/AboutActivity.java
@@ -37,6 +37,8 @@ public class AboutActivity extends AppCompatActivity implements OnItemClickListe
         setTitle(getString(R.string.about));
         setSupportActionBar(toolbar);
 
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
         LinearLayoutManager llm = new LinearLayoutManager(this);
         llm.setOrientation(LinearLayoutManager.VERTICAL);
         recyclerView.setLayoutManager(llm);

--- a/skunkworks_crow/src/main/java/org/odk/share/activities/InstanceManagerTabs.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/activities/InstanceManagerTabs.java
@@ -48,6 +48,8 @@ public class InstanceManagerTabs extends InjectableActivity implements TabLayout
 
         setSupportActionBar(toolbar);
 
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
         String formId = getIntent().getStringExtra(FORM_ID);
 
         if (formId == null) {

--- a/skunkworks_crow/src/main/java/org/odk/share/activities/SendFormsActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/activities/SendFormsActivity.java
@@ -29,6 +29,7 @@ public class SendFormsActivity extends InjectableActivity {
         ButterKnife.bind(this);
 
         setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         setupViewPager(viewPager);
         tabLayout.setupWithViewPager(viewPager);

--- a/skunkworks_crow/src/main/java/org/odk/share/activities/WifiActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/activities/WifiActivity.java
@@ -114,6 +114,8 @@ public class WifiActivity extends InjectableActivity implements OnItemClickListe
         setTitle(getString(R.string.connect_wifi));
         setSupportActionBar(toolbar);
 
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
         isQRCodeScanned = false;
         ssidScanned = null;
         isProtected = false;

--- a/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
@@ -33,7 +33,6 @@ public class SettingsPreference extends PreferenceActivity {
         ViewGroup root = getRootView();
         Toolbar toolbar = (Toolbar) View.inflate(this, R.layout.toolbar, null);
         toolbar.setTitle(getString(R.string.settings));
-
         root.addView(toolbar, 0);
 
         addPreferencesFromResource(R.xml.preferences_menu);


### PR DESCRIPTION
Closes #108 

<!-- 
Thank you for contributing to ODK!
-->
#### Changes:
- [x] Added up button in WifiActivity
- [x] Added up button in AboutActivity
- [x] Added up button in InstanceManagerTabs
- [x] Added up button in Send Forms Activity

#### What has been done to verify that this works as intended?
Tested it in circumstances such as:
* Clicking on the up button.
* Pressing back

#### GIF Showing The Changes
<img src="https://user-images.githubusercontent.com/36811908/54459784-8b9e2680-4789-11e9-8627-8031dacc2298.gif" height="700" width="394">

#### Why is this the best possible solution? Were any other approaches considered?
This is the best possible solution according to [Android Documentation](https://developer.android.com/training/appbar/up-action)
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No risks are associated with these changes. 
#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).