### PR TITLE
Buttons removed in "Sent" tab

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/fragments/SentInstancesFragment.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/fragments/SentInstancesFragment.java
@@ -162,7 +162,7 @@ public class SentInstancesFragment extends InstanceListFragment {
 
     private void setEmptyViewVisibility(String text) {
         if (transferInstanceList.size() > 0) {
-            buttonLayout.setVisibility(View.VISIBLE);
+            buttonLayout.setVisibility(View.INVISIBLE);
             emptyView.setVisibility(View.GONE);
         } else {
             buttonLayout.setVisibility(View.GONE);

--- a/skunkworks_crow/src/main/java/org/odk/share/fragments/SentInstancesFragment.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/fragments/SentInstancesFragment.java
@@ -8,7 +8,6 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -44,10 +43,6 @@ public class SentInstancesFragment extends InstanceListFragment {
 
     @BindView(R.id.recyclerview)
     RecyclerView recyclerView;
-    @BindView(R.id.bToggle)
-    Button toggleButton;
-    @BindView(R.id.bAction)
-    Button sendButton;
     @BindView(R.id.empty_view)
     TextView emptyView;
     @BindView(R.id.buttonholder)
@@ -84,8 +79,6 @@ public class SentInstancesFragment extends InstanceListFragment {
         llm.setOrientation(LinearLayoutManager.VERTICAL);
         recyclerView.setLayoutManager(llm);
 
-        toggleButton.setText(getString(R.string.select_all));
-        sendButton.setText(getString(R.string.send_forms));
 
         setupAdapter();
         return view;
@@ -162,10 +155,8 @@ public class SentInstancesFragment extends InstanceListFragment {
 
     private void setEmptyViewVisibility(String text) {
         if (transferInstanceList.size() > 0) {
-            buttonLayout.setVisibility(View.INVISIBLE);
             emptyView.setVisibility(View.GONE);
         } else {
-            buttonLayout.setVisibility(View.GONE);
             emptyView.setVisibility(View.VISIBLE);
             emptyView.setText(text);
         }


### PR DESCRIPTION
Closes #184 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I made the app run on a device and it's showing the expected result.
The two buttons "Send" and "Select All" are removed as there was no use of them.

#### Why is this the best possible solution? Were any other approaches considered?
This was the best possible solution for the result to be seen and redundancy to be eliminated

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It improves the UI/UX.
![sent1](https://user-images.githubusercontent.com/42612183/54066654-ce2ba480-4259-11e9-9565-c634689691d4.gif)


#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).