### PR TITLE
Statistics fragment issue fixed

### DIFF
--- a/skunkworks_crow/src/main/res/layout/fragment_stats.xml
+++ b/skunkworks_crow/src/main/res/layout/fragment_stats.xml
@@ -1,42 +1,49 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="10dp">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
-    <View
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1.0" />
+        android:orientation="vertical"
+        android:padding="10dp">
 
-    <TextView
-        android:id="@+id/formTitle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:paddingTop="10dp"
-        android:textColor="@color/colorPrimary"
-        android:textSize="21sp"
-        android:textStyle="bold" />
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1.0" />
 
-    <TextView
-        android:id="@+id/formSubTitle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:paddingBottom="20dp"
-        android:textColor="@color/colorPrimary"
-        android:textSize="18sp" />
+        <TextView
+            android:id="@+id/formTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:paddingTop="10dp"
+            android:textColor="@color/colorPrimary"
+            android:textSize="21sp"
+            android:textStyle="bold" />
 
-    <com.github.mikephil.charting.charts.BarChart
-        android:id="@+id/chart"
-        android:layout_width="362dp"
-        android:layout_height="184dp" />
+        <TextView
+            android:id="@+id/formSubTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:paddingBottom="20dp"
+            android:textColor="@color/colorPrimary"
+            android:textSize="18sp" />
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1.0" />
-</LinearLayout>
+        <com.github.mikephil.charting.charts.BarChart
+            android:id="@+id/chart"
+            android:layout_width="362dp"
+            android:layout_height="184dp" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1.0" />
+    </LinearLayout>
+</ScrollView>

--- a/skunkworks_crow/src/main/res/layout/fragment_stats.xml
+++ b/skunkworks_crow/src/main/res/layout/fragment_stats.xml
@@ -39,8 +39,9 @@
         <com.github.mikephil.charting.charts.BarChart
             android:id="@+id/chart"
             android:layout_width="362dp"
-            android:layout_height="184dp" />
-
+            android:layout_height="184dp"
+            android:layout_gravity="center"/>
+        
         <View
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/skunkworks_crow/src/main/res/layout/fragment_stats.xml
+++ b/skunkworks_crow/src/main/res/layout/fragment_stats.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     android:fillViewport="true">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <LinearLayout 
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"


### PR DESCRIPTION
Closes #204 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I made it run on my Android Device and it is showing the expected result.

![rotate1](https://user-images.githubusercontent.com/42612183/54154681-7d3dcb00-4468-11e9-87dc-1e35b3b78e39.gif)



#### Why is this the best possible solution? Were any other approaches considered?
This is perhaps the best solution. Just a few lines of code added to the file

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It improves UI/UX. Now the users would be able to view the whole "Statistics" activity.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).