### PR TITLE
Hotspot name is changing immediately now

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
@@ -76,6 +76,9 @@ public class SettingsPreference extends PreferenceActivity {
                         Toast.makeText(getBaseContext(), getString(R.string.hotspot_name_error), Toast.LENGTH_LONG).show();
                         return false;
                     }
+                    else{
+                        hotspotNamePreference.setSummary(name);
+                    }
                     break;
                 case PreferenceKeys.KEY_HOTSPOT_PASSWORD:
                     String password = newValue.toString();

--- a/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
@@ -75,8 +75,7 @@ public class SettingsPreference extends PreferenceActivity {
                     if (name.length() == 0) {
                         Toast.makeText(getBaseContext(), getString(R.string.hotspot_name_error), Toast.LENGTH_LONG).show();
                         return false;
-                    }
-                    else{
+                    } else {
                         hotspotNamePreference.setSummary(name);
                     }
                     break;


### PR DESCRIPTION
Closes #153 

<!-- 
Thank you for contributing to ODK!
-->
## Description

#### What has been done to verify that this works as intended?
Tested on my phone Samsung J8 is working fine as expected

#### Why is this the best possible solution? Were any other approaches considered?
I gave the else statement in that I made using the setsummary so then it is updating immediately

#### How does this change affect users? 
By updating the name immediately the user knows he updated the name instead of he has to come back

#### GIF 

![immediately](https://user-images.githubusercontent.com/48018942/54203031-5ed2e080-44f7-11e9-8bff-0c64512fd27b.gif)


#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).