### PR TITLE
Update target sdk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 12 21:47:54 IST 2018
+#Wed Mar 20 08:07:11 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/skunkworks_crow/build.gradle
+++ b/skunkworks_crow/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.application'
 apply from: '../config/quality.gradle'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "org.odk.share"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/skunkworks_crow/build.gradle
+++ b/skunkworks_crow/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.application'
 apply from: '../config/quality.gradle'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 27
     defaultConfig {
         applicationId "org.odk.share"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/skunkworks_crow/src/main/java/org/odk/share/activities/MainActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/activities/MainActivity.java
@@ -1,10 +1,12 @@
 package org.odk.share.activities;
 
+import android.Manifest;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.LoaderManager;
@@ -45,7 +47,7 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
     public static final String FORM_DISPLAY_NAME = "form_display_name";
     private static final String FORM_CHOOSER_LIST_SORTING_ORDER = "formChooserListSortingOrder";
     private static final String COLLECT_PACKAGE = "org.odk.collect.android";
-
+    private static final int STORAGE_PERMISSION_REQUEST_CODE = 101;
     private static final int FORM_LOADER = 2;
 
     @BindView(R.id.toolbar)
@@ -84,21 +86,17 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
         sendForms.setEnabled(false);
 
         LinearLayoutManager llm = new LinearLayoutManager(this);
-        llm.setOrientation(LinearLayoutManager.VERTICAL);
+        llm.setOrientation(RecyclerView.VERTICAL);
         recyclerView.setLayoutManager(llm);
-        setupAdapter();
-        getSupportLoaderManager().initLoader(FORM_LOADER, null, this);
-        addListItemDivider();
-    }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        if (isCollectInstalled()) {
-            updateAdapter();
-        } else {
-            showAlertDialog();
-        }
+        //check the storage permission and start the loader
+        setUpLoader();
+
+        emptyView.setOnClickListener((View view) -> {
+            setUpLoader();
+        });
+
+        addListItemDivider();
     }
 
     private void setupAdapter() {
@@ -154,6 +152,7 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
 
     @Override
     public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
+
         formAdapter.changeCursor(cursor);
         if (cursor != null && !cursor.isClosed()) {
             setEmptyViewVisibility(cursor.getCount());
@@ -237,4 +236,42 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
 
     }
 
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        switch (requestCode) {
+            case STORAGE_PERMISSION_REQUEST_CODE:
+                if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    setUpLoader();
+                } else {
+                    showNoPermissionView();
+                }
+        }
+    }
+
+    private void showNoPermissionView() {
+
+        setEmptyViewVisibility(0);
+        emptyView.setText(getString(R.string.provide_storage_permission));
+    }
+
+    private void setUpLoader() {
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
+                checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+
+            setupAdapter();
+            getSupportLoaderManager().initLoader(FORM_LOADER, null, this);
+
+            if (isCollectInstalled()) {
+                updateAdapter();
+            } else {
+                showAlertDialog();
+            }
+        } else {
+            requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE , Manifest.permission.READ_EXTERNAL_STORAGE},
+                    STORAGE_PERMISSION_REQUEST_CODE);
+        }
+    }
 }

--- a/skunkworks_crow/src/main/java/org/odk/share/activities/SendActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/activities/SendActivity.java
@@ -1,16 +1,19 @@
 package org.odk.share.activities;
 
+import android.Manifest;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
@@ -53,6 +56,7 @@ public class SendActivity extends InjectableActivity {
     public static final String DEFAULT_SSID = "ODK-SKUNKWORKS";
     private static final int PROGRESS_DIALOG = 1;
     private final CompositeDisposable compositeDisposable = new CompositeDisposable();
+    private static final int LOCATION_PERMISSION_REQUEST_CODE = 102;
 
     @Inject
     RxEventBus rxEventBus;
@@ -174,7 +178,7 @@ public class SendActivity extends InjectableActivity {
             Intent intent = new Intent(getApplicationContext(), HotspotService.class);
             intent.setAction(HotspotService.ACTION_STATUS);
             startService(intent);
-            
+
             currentConfig = wifiHotspot.getCurrConfig();
             startSending();
         }
@@ -252,24 +256,8 @@ public class SendActivity extends InjectableActivity {
         compositeDisposable.add(addHotspotEventSubscription());
         compositeDisposable.add(addUploadEventSubscription());
 
-        if (!isHotspotInitiated) {
-            isHotspotInitiated = true;
-            startHotspot();
-        }
-
-        if (openSettings) {
-            openSettings = false;
-            Intent serviceIntent = new Intent(getApplicationContext(), HotspotService.class);
-            serviceIntent.setAction(HotspotService.ACTION_START);
-            startService(serviceIntent);
-
-            Intent intent = new Intent(getApplicationContext(), HotspotService.class);
-            intent.setAction(HotspotService.ACTION_STATUS);
-            startService(intent);
-            Timber.d("Started hotspot N");
-            currentConfig = wifiHotspot.getCurrConfig();            
-            startSending();
-        }
+        //location permission is needed for using hotspot
+        checkLocationPermission();
     }
 
     private Disposable addUploadEventSubscription() {
@@ -423,5 +411,55 @@ public class SendActivity extends InjectableActivity {
         alertDialog.setCancelable(false);
         alertDialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.ok), quitListener);
         alertDialog.show();
+    }
+
+    private void checkLocationPermission() {
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
+                checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+
+            toggleHotspot();
+        } else {
+            requestPermissions(new String[]{Manifest.permission.ACCESS_COARSE_LOCATION} , LOCATION_PERMISSION_REQUEST_CODE);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        switch (requestCode) {
+
+            case LOCATION_PERMISSION_REQUEST_CODE:
+                if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    toggleHotspot();
+                } else {
+                    Toast.makeText(this, getString(R.string.location_permission_needed), Toast.LENGTH_SHORT).show();
+                    this.finish();
+                }
+                break;
+        }
+    }
+
+    private void toggleHotspot() {
+
+        if (!isHotspotInitiated) {
+            isHotspotInitiated = true;
+            startHotspot();
+        }
+
+        if (openSettings) {
+            openSettings = false;
+            Intent serviceIntent = new Intent(getApplicationContext(), HotspotService.class);
+            serviceIntent.setAction(HotspotService.ACTION_START);
+            startService(serviceIntent);
+
+            Intent intent = new Intent(getApplicationContext(), HotspotService.class);
+            intent.setAction(HotspotService.ACTION_STATUS);
+            startService(intent);
+            Timber.d("Started hotspot N");
+            currentConfig = wifiHotspot.getCurrConfig();
+            startSending();
+        }
     }
 }

--- a/skunkworks_crow/src/main/res/values/strings.xml
+++ b/skunkworks_crow/src/main/res/values/strings.xml
@@ -129,4 +129,6 @@
     <string name="default_odk_destination_dir">\/sdcard\/odk</string>
     <string name="title_odk_destination_dir">ODK Destination Directory</string>
     <string name="odk_destination_dir_error">The destination should not be empty</string>
+    <string name="location_permission_needed">Location Permission Needed</string>
+    <string name="provide_storage_permission">Click here to give storage permission</string>
 </resources>


### PR DESCRIPTION
Closes #119 

#### What has been done to verify that this works as intended?
runtime time permissions for storage, location, camera are asked depending on the SDK version
and fallback scenario if the user denied the permission is also provided.

#### Why is this the best possible solution? Were any other approaches considered?
asked permissions at the required time. no specific approach used.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
for end users running on android M and above needs to provide the required run time permission. have to modularise few code so that they can run once the permission is accepted.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).