### PR TITLE
[#219]  checks if gps is on for >= oreo, when hotspot is turned on

### DIFF
--- a/skunkworks_crow/src/main/res/values/strings.xml
+++ b/skunkworks_crow/src/main/res/values/strings.xml
@@ -129,4 +129,5 @@
     <string name="default_odk_destination_dir">\/sdcard\/odk</string>
     <string name="title_odk_destination_dir">ODK Destination Directory</string>
     <string name="odk_destination_dir_error">The destination should not be empty</string>
+    <string name="location_settings_dialog">Enable location from the settings.</string>
 </resources>


### PR DESCRIPTION
Closes #219 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
- Checked and verified starting hot stop was blocked and only resumed once app had location permission
on one plus 3T (Oreo) and Android Emulator (Oreo).
- It sets `isHotspotInitiated` as false, if location is not turned on while trying to use hotspot. so it fits with the existing logic

#### Why is this the best possible solution? Were any other approaches considered?
- Maybe move `isGPSenabled()` to a util class
- Add runtime permissions  along with checking if GPS is enabled, but version code is set to 22 so that's probably a no for now


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
- User's with Oreo or higher see a dialog to turn on location, while trying to send a file.
- My changes conflict with #218 

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).