### PR TITLE
🚑 quickfix: Added permission check when first enter application

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/activities/MainActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/activities/MainActivity.java
@@ -81,7 +81,7 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
 
         setTitle(getString(R.string.app_name));
         setSupportActionBar(toolbar);
-        Share.createODKDirs(this);
+        createODKDirs();
 
         sendForms.setEnabled(false);
 
@@ -220,6 +220,17 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
 
         builder.setCancelable(false);
         builder.show();
+    }
+
+    // call createODKDirs() with a permission check.
+    private void createODKDirs() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
+                checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+            Share.createODKDirs(this);
+        } else {
+            requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE},
+                    STORAGE_PERMISSION_REQUEST_CODE);
+        }
     }
 
     private void addListItemDivider() {


### PR DESCRIPTION
Closes #228 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I have test in my Nexus 6P new device.

#### Why is this the best possible solution? Were any other approaches considered?
I just wrapped the method `createODKDirs()` since only the first time we install the application, and without an ODK dir (without permission to storage) will face this error.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
N/A
#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).