### PR TITLE
[#216] replaced edittextpref with textinputlayout dialog

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
@@ -157,7 +157,5 @@ public class SettingsPreference extends PreferenceActivity {
         AlertDialog alertDialog = builder.create();
         alertDialog.show();
     }
-
-
 }
 

--- a/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
@@ -1,6 +1,5 @@
 package org.odk.share.preferences;
 
-import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
@@ -12,21 +11,13 @@ import android.preference.PreferenceManager;
 import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
-import android.text.InputType;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowManager;
-import android.widget.Button;
-import android.widget.CheckBox;
-import android.widget.EditText;
 import android.widget.Toast;
 
 import org.odk.share.R;
-import org.odk.share.network.WifiNetworkInfo;
-
-import timber.log.Timber;
 
 
 /**

--- a/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/preferences/SettingsPreference.java
@@ -152,6 +152,7 @@ public class SettingsPreference extends PreferenceActivity {
 
         View dialogView = factory.inflate(R.layout.dialog_password_til, null);
         TextInputLayout tlPassword = dialogView.findViewById(R.id.et_password_layout);
+        tlPassword.getEditText().setText(prefs.getString(PreferenceKeys.KEY_HOTSPOT_PASSWORD, getString(R.string.default_hotspot_password)));
 
         builder.setTitle(getString(R.string.title_hotspot_password));
         builder.setView(dialogView);

--- a/skunkworks_crow/src/main/res/layout/dialog_password_til.xml
+++ b/skunkworks_crow/src/main/res/layout/dialog_password_til.xml
@@ -1,0 +1,14 @@
+<android.support.design.widget.TextInputLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/et_password_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp"
+    app:passwordToggleEnabled="true">
+
+    <android.support.design.widget.TextInputEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="textPassword" />
+</android.support.design.widget.TextInputLayout>

--- a/skunkworks_crow/src/main/res/xml/preferences_menu.xml
+++ b/skunkworks_crow/src/main/res/xml/preferences_menu.xml
@@ -10,7 +10,7 @@
             android:key="hotspot_name"
             android:icon="@drawable/ic_wifi_tethering_black_24dp"/>
 
-        <android.preference.EditTextPreference
+        <Preference
             android:defaultValue="@string/default_hotspot_password"
             android:summary="********"
             android:title="@string/title_hotspot_password"


### PR DESCRIPTION
Closes #216 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
- Opened settings screen
- Checked if toggle worked
- Checked if changed password was saved
- Checked if default password was loaded, when setting password for the first time

![password-toggle](https://user-images.githubusercontent.com/11831955/55251006-a1c2e100-5277-11e9-9a53-429b512d0f6d.gif)

#### Why is this the best possible solution? Were any other approaches considered?
- Easiest method of achieving password toggle
- However, using a checkbox to toggle was considered but was quickly ruled out after following the discussion on #221 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
- User can now toggle password in input area



#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).