### PR TITLE
Stops app crash on entering received forms

### DIFF
--- a/skunkworks_crow/build.gradle
+++ b/skunkworks_crow/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-alpha4'
     implementation 'com.google.android.material:material:1.0.0'
 
-
     // butterknife
     implementation "com.jakewharton:butterknife:${rootProject.butterknifeVersion}"
     annotationProcessor "com.jakewharton:butterknife-compiler:${rootProject.butterknifeVersion}"

--- a/skunkworks_crow/build.gradle
+++ b/skunkworks_crow/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "org.odk.share"
-        minSdkVersion 16
+        minSdkVersion 22
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
@@ -31,6 +31,8 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-alpha4'
+    implementation 'com.google.android.material:material:1.0.0'
+
 
     // butterknife
     implementation "com.jakewharton:butterknife:${rootProject.butterknifeVersion}"

--- a/skunkworks_crow/build.gradle
+++ b/skunkworks_crow/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "org.odk.share"
-        minSdkVersion 22
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/skunkworks_crow/build.gradle
+++ b/skunkworks_crow/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-alpha4'
-    implementation 'com.google.android.material:material:1.0.0'
 
     // butterknife
     implementation "com.jakewharton:butterknife:${rootProject.butterknifeVersion}"

--- a/skunkworks_crow/src/main/res/layout/activity_review_form.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_review_form.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -48,7 +49,8 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/add_feedback"
                     android:inputType="text"
-                    android:textSize="18sp" />
+                    android:textSize="18sp"
+                    tools:ignore="Autofill" />
 
             </com.google.android.material.textfield.TextInputLayout>
 

--- a/skunkworks_crow/src/main/res/layout/activity_review_form.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_review_form.xml
@@ -37,7 +37,7 @@
                 android:textSize="21sp"
                 android:textStyle="bold"/>
 
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/input_layout_feedback"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
@@ -49,8 +49,8 @@
                     android:inputType="text"
                     android:textSize="18sp"
                     android:hint="@string/add_feedback"/>
-
-            </android.support.design.widget.TextInputLayout>
+                
+            </com.google.android.material.textfield.TextInputLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/skunkworks_crow/src/main/res/layout/activity_review_form.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_review_form.xml
@@ -9,9 +9,9 @@
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_below="@id/toolbar"
         android:fillViewport="true"
-        android:orientation="vertical"
-        android:layout_below="@id/toolbar">
+        android:orientation="vertical">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -31,11 +31,11 @@
                 android:layout_gravity="center"
                 android:gravity="center"
                 android:lineSpacingMultiplier="1.2"
-                android:paddingBottom="20dp"
                 android:paddingTop="10dp"
+                android:paddingBottom="20dp"
                 android:textColor="@color/colorPrimary"
                 android:textSize="21sp"
-                android:textStyle="bold"/>
+                android:textStyle="bold" />
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/input_layout_feedback"
@@ -46,10 +46,10 @@
                     android:id="@+id/save_feedback"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:hint="@string/add_feedback"
                     android:inputType="text"
-                    android:textSize="18sp"
-                    android:hint="@string/add_feedback"/>
-                
+                    android:textSize="18sp" />
+
             </com.google.android.material.textfield.TextInputLayout>
 
             <LinearLayout
@@ -59,18 +59,18 @@
                 android:weightSum="2">
 
                 <Button
+                    android:id="@+id/bApprove"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/approve"
-                    android:id="@+id/bApprove"
-                    android:layout_weight="1" />
+                    android:layout_weight="1"
+                    android:text="@string/approve" />
 
                 <Button
+                    android:id="@+id/bReject"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/Reject"
-                    android:id="@+id/bReject"
-                    android:layout_weight="1"/>
+                    android:layout_weight="1"
+                    android:text="@string/Reject" />
 
             </LinearLayout>
 
@@ -82,10 +82,10 @@
                 android:text="@string/view_form_in_collect" />
 
             <Button
+                android:id="@+id/bReviewLater"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/review_later"
-                android:id="@+id/bReviewLater" />
+                android:text="@string/review_later" />
 
             <View
                 android:layout_width="match_parent"


### PR DESCRIPTION
Closes #236 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
1. Checks if the app is crashing on clicking received forms 
2. Checked any new warnings are produced
3. Whether it is directing to review form 

#### Why is this the best possible solution? Were any other approaches considered?
The app is crashing due to `android.support.design.widget.TextInputLayout` so I imported dependencies from `google android material` 
and stopped the warning of `autofill`


#### How does this change affect users? 
App crash is not at all the good behavior, so removed that behavior
by directing into review form so the user can review the forms or view it on ODK collect 

### GIF
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/48018942/55570270-b47a6180-5720-11e9-8b49-145d3669da88.gif)


#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).