### PR TITLE
Fixed App crash in open source licenses

### DIFF
--- a/skunkworks_crow/src/main/res/layout/activity_web_view.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_web_view.xml
@@ -1,32 +1,30 @@
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginBottom="0dp"
     android:layout_marginLeft="0dp"
-    android:layout_marginRight="0dp"
     android:layout_marginTop="0dp"
+    android:layout_marginRight="0dp"
+    android:layout_marginBottom="0dp"
     android:orientation="vertical"
     android:padding="0dp">
 
-    <android.support.v7.widget.Toolbar
-        xmlns:android="http://schemas.android.com/apk/res/android"
+    <androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content" />
 
     <ProgressBar
         android:id="@+id/progressBar"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:indeterminate="true"
-        android:layout_below="@+id/toolbar"/>
+        android:layout_below="@+id/toolbar"
+        android:indeterminate="true" />
 
     <WebView
         android:id="@+id/webView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/progressBar"/>
+        android:layout_below="@id/progressBar" />
 
 </RelativeLayout>

--- a/skunkworks_crow/src/main/res/layout/activity_web_view.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_web_view.xml
@@ -8,7 +8,7 @@
     android:orientation="vertical"
     android:padding="0dp">
 
-    <androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />


### PR DESCRIPTION
Closes #245 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
Checked whether App is crashing or not
checked whether web view of open source licenses are opening or not
And checked any new warnings are producing  

#### Why is this the best possible solution? Were any other approaches considered?
As by using `android.support.v7.widget.Toolbar` so the layout is inflating so I changed to  `androidx.appcompat.widget.Toolbar ` so by using the support of android RX so I fixed that

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

By solving the app crash on clicking so that a user can see the web view of open source licenses
 

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).