### PR TITLE
[MRG] Removed the unreachable bluetooth devices.

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BluetoothListAdapter.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BluetoothListAdapter.java
@@ -21,6 +21,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 
 import static android.bluetooth.BluetoothDevice.BOND_BONDED;
+import static android.bluetooth.BluetoothDevice.BOND_NONE;
 
 
 /**
@@ -69,7 +70,7 @@ public class BluetoothListAdapter extends RecyclerView.Adapter<BluetoothListAdap
         int deviceBondState = device.getBondState();
         viewHolder.deviceName.setText(deviceName == null ? viewHolder.itemView.getResources().getString(R.string.bluetooth_instance_name_default) : deviceName);
         viewHolder.deviceAddress.setText(String.format("%s (%s)", deviceAddress,
-                deviceBondState == 10 ? context.getString(R.string.bluetooth_unpaired) : context.getString(R.string.bluetooth_paired)));
+                deviceBondState == BOND_NONE ? context.getString(R.string.bluetooth_unpaired) : context.getString(R.string.bluetooth_paired)));
         if (device.getBondState() == BOND_BONDED) {
             viewHolder.deviceLogo.setImageResource(R.drawable.ic_smart_phone_yellow);
         }

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BluetoothListAdapter.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BluetoothListAdapter.java
@@ -71,7 +71,7 @@ public class BluetoothListAdapter extends RecyclerView.Adapter<BluetoothListAdap
         viewHolder.deviceName.setText(deviceName == null ? viewHolder.itemView.getResources().getString(R.string.bluetooth_instance_name_default) : deviceName);
         viewHolder.deviceAddress.setText(String.format("%s (%s)", deviceAddress,
                 deviceBondState == BOND_NONE ? context.getString(R.string.bluetooth_unpaired) : context.getString(R.string.bluetooth_paired)));
-        if (device.getBondState() == BOND_BONDED) {
+        if (deviceBondState == BOND_BONDED) {
             viewHolder.deviceLogo.setImageResource(R.drawable.ic_smart_phone_yellow);
         }
     }

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtReceiverActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtReceiverActivity.java
@@ -23,8 +23,6 @@ import org.odk.share.rx.schedulers.BaseSchedulerProvider;
 import org.odk.share.services.ReceiverService;
 import org.odk.share.views.ui.common.injectable.InjectableActivity;
 
-import java.util.Set;
-
 import javax.inject.Inject;
 
 import butterknife.BindView;
@@ -85,20 +83,9 @@ public class BtReceiverActivity extends InjectableActivity implements
     }
 
     /**
-     * Add the bounded bluetooth devices.
-     */
-    public void addPairedDevices() {
-        Set<BluetoothDevice> bondedDevices = bluetoothAdapter.getBondedDevices();
-        if (bondedDevices != null) {
-            bluetoothListAdapter.addDevices(bondedDevices);
-        }
-    }
-
-    /**
      * Rescan the bluetooth devices and update the list.
      */
     public void updateDeviceList() {
-        addPairedDevices();
         if (!bluetoothAdapter.isDiscovering()) {
             bluetoothAdapter.startDiscovery();
         }
@@ -114,7 +101,6 @@ public class BtReceiverActivity extends InjectableActivity implements
         recyclerView.setLayoutManager(linearLayoutManager);
         recyclerView.setAdapter(bluetoothListAdapter);
         bluetoothReceiver = new BluetoothReceiver(this, this);
-        addPairedDevices();
         bluetoothAdapter.startDiscovery();
 
         // click to refresh the devices list.


### PR DESCRIPTION
Closes #275 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I just removed the `addBondedDevices()` method, since we don't need all the paired devices. 
Those changes tested well in my Nexus 6P and Samsung Galaxy note3. 

#### Why is this the best possible solution? Were any other approaches considered?
Though we removed the `addBondedDevices()` method, but we can still see the differences between the paired devices and the unpaired devices. So I think this is the best solution.  

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
N/A
#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).