### PR TITLE
[MRG] Fixed the socket closed issue

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/tasks/UploadJob.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/tasks/UploadJob.java
@@ -172,12 +172,6 @@ public class UploadJob extends Job {
         } catch (IOException e) {
             Timber.e(e);
             return new UploadEvent(UploadEvent.Status.ERROR, e.getMessage());
-        } finally {
-            try {
-                closeConnections();
-            } catch (IOException e) {
-                Timber.e(e);
-            }
         }
 
         return new UploadEvent(UploadEvent.Status.FINISHED, sbResult.toString());


### PR DESCRIPTION
Closes #267 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I have tested the PR using my Nexus 6P (android 8.0.1). The issue never appear again, everything went well.

#### Why is this the best possible solution? Were any other approaches considered?
This issue comes from the `finally` block, it is totally unnecessary. 

```java
        try {
            // show dialog and connected
            Timber.d("Start Sending");
            processSelectedFiles(instancesToSend);
            closeConnections();
        } catch (IOException e) {
            Timber.e(e);
            return new UploadEvent(UploadEvent.Status.ERROR, e.getMessage());
        } finally {
            try {
                closeConnections();
            } catch (IOException e) {
                Timber.e(e);
            }
        }
```

We have already called the `closeConnections()` in the `try-catch` block and the exception comes from the `closeConnections()`, so we don't have to call `closeConnections()` again in the `finally` block, this will conduct we call this method twice and in the second time we will face the socket closed issue. So the way to fix that is remove the `finally` block and make sure that only called once.


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Tested with no issues.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).