### PR TITLE
[MRG] 🚑 quickfix: remove the previous devices list when refresh.

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BluetoothListAdapter.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BluetoothListAdapter.java
@@ -122,6 +122,7 @@ public class BluetoothListAdapter extends RecyclerView.Adapter<BluetoothListAdap
      */
     public void clearBluetoothDeviceList() {
         bluetoothDeviceList.clear();
+        notifyDataSetChanged();
     }
 
     /**

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtReceiverActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtReceiverActivity.java
@@ -190,6 +190,7 @@ public class BtReceiverActivity extends InjectableActivity implements
     @Override
     public void onDiscoveryStarted() {
         checkEmptyList();
+        bluetoothListAdapter.clearBluetoothDeviceList();
     }
 
     @Override


### PR DESCRIPTION
Closes #282 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I didn't test this change, but the code makes sense. Why I didn't test that? the code still has issues that were fixed in the PR #272 . To make sure everything is safe, we can have tests after that was merged.

#### Why is this the best possible solution? Were any other approaches considered?
Clearing the devices list every time when we are starting scanning is the easiest way and can also make sure we won't forget any other cases.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
N/A

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).