### PR TITLE
[MRG] Fixed the storage permission handling progress.

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/utilities/PermissionUtils.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/utilities/PermissionUtils.java
@@ -65,9 +65,10 @@ public class PermissionUtils {
     /**
      * Showing an alert dialog and send users to app info page.
      */
-    public static void showAppInfo(Activity targetActivity, String packageName) {
+    public static void showAppInfo(Activity targetActivity, String packageName,
+                                   String msg, String deniedMsg) {
         AlertDialog.Builder builder = new AlertDialog.Builder(targetActivity);
-        builder.setMessage(R.string.permission_open_info);
+        builder.setMessage(msg);
 
         builder.setPositiveButton(targetActivity.getString(R.string.permission_open_info_button), (DialogInterface dialog, int which) -> {
             Intent intent = new Intent();
@@ -79,7 +80,7 @@ public class PermissionUtils {
 
         builder.setNegativeButton(targetActivity.getString(R.string.cancel), (DialogInterface dialog, int which) -> {
             dialog.dismiss();
-            Toast.makeText(targetActivity, R.string.permission_location_denied, Toast.LENGTH_SHORT).show();
+            Toast.makeText(targetActivity, deniedMsg, Toast.LENGTH_SHORT).show();
             targetActivity.finish();
         });
 

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtReceiverActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtReceiverActivity.java
@@ -45,7 +45,7 @@ import timber.log.Timber;
 import static org.odk.share.utilities.PermissionUtils.APP_SETTING_REQUEST_CODE;
 
 /**
- * Receive activity, for testing, needs refactor.
+ * Bluetooth receiver activity.
  *
  * @author huangyz0918 (huangyz0918@gmail.com)
  */
@@ -161,7 +161,7 @@ public class BtReceiverActivity extends InjectableActivity implements
     @OnNeverAskAgain({Manifest.permission.ACCESS_FINE_LOCATION,
             Manifest.permission.ACCESS_COARSE_LOCATION})
     void showNeverAskForLocation() {
-        PermissionUtils.showAppInfo(this, getPackageName());
+        PermissionUtils.showAppInfo(this, getPackageName(), getString(R.string.permission_open_location_info), getString(R.string.permission_location_denied));
     }
 
     @Override

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtSenderActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtSenderActivity.java
@@ -48,7 +48,7 @@ import static org.odk.share.views.ui.send.fragment.BlankFormsFragment.FORM_IDS;
 
 
 /**
- * Send activity, for testing, needs refactor.
+ * Bluetooth sender activity.
  *
  * @author huangyz0918 (huangyz0918@gmail.com)
  */
@@ -184,7 +184,7 @@ public class BtSenderActivity extends InjectableActivity {
     @OnNeverAskAgain({Manifest.permission.ACCESS_FINE_LOCATION,
             Manifest.permission.ACCESS_COARSE_LOCATION})
     void showNeverAskForLocation() {
-        PermissionUtils.showAppInfo(this, getPackageName());
+        PermissionUtils.showAppInfo(this, getPackageName(), getString(R.string.permission_open_location_info), getString(R.string.permission_location_denied));
     }
 
     @Override
@@ -207,7 +207,7 @@ public class BtSenderActivity extends InjectableActivity {
             case APP_SETTING_REQUEST_CODE:
                 if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
                         != PackageManager.PERMISSION_GRANTED) {
-                    PermissionUtils.showAppInfo(this, getPackageName());
+                    PermissionUtils.showAppInfo(this, getPackageName(), getString(R.string.permission_open_location_info), getString(R.string.permission_location_denied));
                 } else {
                     BtSenderActivityPermissionsDispatcher.enableDiscoveryWithPermissionCheck(this);
                 }

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
@@ -257,7 +257,6 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
                     setUpLoader();
                 } else {
                     if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                            checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED &&
                             !shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE))) {
                         PermissionUtils.showAppInfo(this, getPackageName(), getString(R.string.permission_open_storage_info), getString(R.string.permission_storage_denied));
                     } else {

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
@@ -251,35 +251,31 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        switch (requestCode) {
-            case STORAGE_PERMISSION_REQUEST_CODE:
-                if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    setUpLoader();
+        if (requestCode == STORAGE_PERMISSION_REQUEST_CODE) {
+            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                setUpLoader();
+            } else {
+                if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                        !shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE))) {
+                    PermissionUtils.showAppInfo(this, getPackageName(), getString(R.string.permission_open_storage_info), getString(R.string.permission_storage_denied));
                 } else {
-                    if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                            !shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE))) {
-                        PermissionUtils.showAppInfo(this, getPackageName(), getString(R.string.permission_open_storage_info), getString(R.string.permission_storage_denied));
-                    } else {
-                        Toast.makeText(this, getString(R.string.permission_storage_denied), Toast.LENGTH_SHORT).show();
-                        finish();
-                    }
+                    Toast.makeText(this, getString(R.string.permission_storage_denied), Toast.LENGTH_SHORT).show();
+                    finish();
                 }
-                break;
+            }
         }
     }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        switch (requestCode) {
-            case APP_SETTING_REQUEST_CODE:
-                if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                        != PackageManager.PERMISSION_GRANTED) {
-                    PermissionUtils.showAppInfo(this, getPackageName(), getString(R.string.permission_open_storage_info), getString(R.string.permission_storage_denied));
-                } else {
-                    setUpLoader();
-                }
-                break;
+        if (requestCode == APP_SETTING_REQUEST_CODE) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    != PackageManager.PERMISSION_GRANTED) {
+                PermissionUtils.showAppInfo(this, getPackageName(), getString(R.string.permission_open_storage_info), getString(R.string.permission_storage_denied));
+            } else {
+                setUpLoader();
+            }
         }
     }
 

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
@@ -14,10 +14,13 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.DividerItemDecoration;
@@ -32,6 +35,7 @@ import org.odk.share.application.Share;
 import org.odk.share.dao.TransferDao;
 import org.odk.share.utilities.ActivityUtils;
 import org.odk.share.utilities.DialogUtils;
+import org.odk.share.utilities.PermissionUtils;
 import org.odk.share.views.listeners.ItemClickListener;
 import org.odk.share.views.ui.about.AboutActivity;
 import org.odk.share.views.ui.common.basecursor.BaseCursorViewHolder;
@@ -45,6 +49,8 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import timber.log.Timber;
+
+import static org.odk.share.utilities.PermissionUtils.APP_SETTING_REQUEST_CODE;
 
 public class MainActivity extends FormListActivity implements LoaderManager.LoaderCallbacks<Cursor>, ItemClickListener {
 
@@ -245,20 +251,40 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-
         switch (requestCode) {
             case STORAGE_PERMISSION_REQUEST_CODE:
                 if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     setUpLoader();
                 } else {
-                    //close the app if the permission is denied
-                    finish();
+                    if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                            checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED &&
+                            !shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE))) {
+                        PermissionUtils.showAppInfo(this, getPackageName(), getString(R.string.permission_open_storage_info), getString(R.string.permission_storage_denied));
+                    } else {
+                        Toast.makeText(this, getString(R.string.permission_storage_denied), Toast.LENGTH_SHORT).show();
+                        finish();
+                    }
                 }
+                break;
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        switch (requestCode) {
+            case APP_SETTING_REQUEST_CODE:
+                if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                        != PackageManager.PERMISSION_GRANTED) {
+                    PermissionUtils.showAppInfo(this, getPackageName(), getString(R.string.permission_open_storage_info), getString(R.string.permission_storage_denied));
+                } else {
+                    setUpLoader();
+                }
+                break;
         }
     }
 
     private void setUpLoader() {
-
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
                 checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
 

--- a/skunkworks_crow/src/main/res/values/strings.xml
+++ b/skunkworks_crow/src/main/res/values/strings.xml
@@ -158,6 +158,8 @@
     <string name="tv_form_send_success">form sent with success! \n</string>
     <string name="bluetooth_no_device_scanned">No devices are available. \n Tap refresh to search again.</string>
     <string name="permission_location_denied">Location permission is required to send the forms using Bluetooth. Please allow it in the app settings.</string>
-    <string name="permission_open_info">Skunkworks-crow app requires location permission to access your Bluetooth. Please allow location permission from your app settings.</string>
+    <string name="permission_storage_denied">Storage permission is required. Please allow it in the app settings.</string>
+    <string name="permission_open_location_info">Skunkworks-crow app requires location permission to access your Bluetooth. Please allow location permission from your app settings.</string>
+    <string name="permission_open_storage_info">Skunkworks-crow app requires storage permission to access ODK database. Please allow that from your app settings.</string>
     <string name="permission_open_info_button">Open Settings</string>
 </resources>


### PR DESCRIPTION
Closes #295 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I didn't use the permission dispatcher lib, since we already has the complete checking code, so I tried to fix this bug without a refactor. But I have tested with the permission dispatcher library as well, maybe something goes wrong with the injector, so the `OnPermissionDenied` would be called every time before I do any operations with the permission request dialog. So I just fixed the issue in the base of current code and make tests in my Nexus 6P (Android 9), everything works well.

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
N/A

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).