### PR TITLE
fix: stop bluetooth after sharing forms according to initial state

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtSenderActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtSenderActivity.java
@@ -85,6 +85,7 @@ public class BtSenderActivity extends InjectableActivity {
     private final CompositeDisposable compositeDisposable = new CompositeDisposable();
     private boolean isFinished = false;
     private boolean isDiscovering = false;
+    private boolean initialStateDisabled = false;
 
     private CountDownTimer countDownTimer;
     private ProgressDialog progressDialog;
@@ -113,6 +114,7 @@ public class BtSenderActivity extends InjectableActivity {
 
         if (!BluetoothUtils.isBluetoothEnabled()) {
             BluetoothUtils.enableBluetooth();
+            initialStateDisabled = true;
         }
 
         if (getIntent() != null) {
@@ -153,7 +155,7 @@ public class BtSenderActivity extends InjectableActivity {
                 .setNegativeButton(getString(R.string.ok), (DialogInterface dialog, int which) -> {
                     dialog.dismiss();
                     senderService.cancel();
-                    if (BluetoothUtils.isBluetoothEnabled()) {
+                    if (BluetoothUtils.isBluetoothEnabled() && initialStateDisabled) {
                         BluetoothUtils.disableBluetooth();
                     }
                     finish();
@@ -172,7 +174,7 @@ public class BtSenderActivity extends InjectableActivity {
             DialogUtils.createMethodSwitchDialog(this, (DialogInterface dialog, int which) -> {
                 receivedIntent.setClass(this, HpSenderActivity.class);
                 senderService.cancel();
-                if (BluetoothUtils.isBluetoothEnabled()) {
+                if (BluetoothUtils.isBluetoothEnabled() && initialStateDisabled) {
                     BluetoothUtils.disableBluetooth();
                 }
                 startActivity(receivedIntent);
@@ -384,7 +386,8 @@ public class BtSenderActivity extends InjectableActivity {
                     .setMessage(getString(R.string.stop_sending_msg))
                     .setPositiveButton(R.string.stop, (DialogInterface dialog, int which) -> {
                         senderService.cancel();
-                        BluetoothUtils.disableBluetooth();
+                        if(initialStateDisabled)
+                            BluetoothUtils.disableBluetooth();
                         super.onBackPressed();
                     })
                     .setNegativeButton(R.string.cancel, (DialogInterface dialog, int which) -> {
@@ -398,7 +401,8 @@ public class BtSenderActivity extends InjectableActivity {
                     .setMessage(getString(R.string.disable_bluetooth_sender_msg))
                     .setPositiveButton(R.string.quit, (DialogInterface dialog, int which) -> {
                         senderService.cancel();
-                        BluetoothUtils.disableBluetooth();
+                        if(initialStateDisabled)
+                            BluetoothUtils.disableBluetooth();
                         super.onBackPressed();
                     })
                     .setNegativeButton(android.R.string.no, (DialogInterface dialog, int which) -> {

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtSenderActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/bluetooth/BtSenderActivity.java
@@ -386,8 +386,9 @@ public class BtSenderActivity extends InjectableActivity {
                     .setMessage(getString(R.string.stop_sending_msg))
                     .setPositiveButton(R.string.stop, (DialogInterface dialog, int which) -> {
                         senderService.cancel();
-                        if(initialStateDisabled)
+                        if (initialStateDisabled) {
                             BluetoothUtils.disableBluetooth();
+                        }
                         super.onBackPressed();
                     })
                     .setNegativeButton(R.string.cancel, (DialogInterface dialog, int which) -> {
@@ -401,8 +402,9 @@ public class BtSenderActivity extends InjectableActivity {
                     .setMessage(getString(R.string.disable_bluetooth_sender_msg))
                     .setPositiveButton(R.string.quit, (DialogInterface dialog, int which) -> {
                         senderService.cancel();
-                        if(initialStateDisabled)
+                        if (initialStateDisabled) {
                             BluetoothUtils.disableBluetooth();
+                        }
                         super.onBackPressed();
                     })
                     .setNegativeButton(android.R.string.no, (DialogInterface dialog, int which) -> {


### PR DESCRIPTION
Closes #306 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
Tested on my Vivo Z1 Pro running on Android 9.x.x

#### Why is this the best possible solution? Were any other approaches considered?
NA

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Now if the Bluetooth is enabled before sharing forms, it will not be disabled after the process is completed.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).