### PR TITLE
fix: Fixed crash while sending forms through hotspot

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/hotspot/HpSenderActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/hotspot/HpSenderActivity.java
@@ -373,29 +373,31 @@ public class HpSenderActivity extends InjectableActivity {
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     private void turnOnHotspot() {
-        WifiManager manager = (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-        manager.startLocalOnlyHotspot(new WifiManager.LocalOnlyHotspotCallback() {
+        if (!isHotspotInitiated) {
+            WifiManager manager = (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+            manager.startLocalOnlyHotspot(new WifiManager.LocalOnlyHotspotCallback() {
 
-            @Override
-            public void onStarted(WifiManager.LocalOnlyHotspotReservation reservation) {
-                super.onStarted(reservation);
-                hotspotReservation = reservation;
-                currentConfig = reservation.getWifiConfiguration();
-                startSending();
-            }
+                @Override
+                public void onStarted(WifiManager.LocalOnlyHotspotReservation reservation) {
+                    super.onStarted(reservation);
+                    hotspotReservation = reservation;
+                    currentConfig = reservation.getWifiConfiguration();
+                    startSending();
+                }
 
-            @Override
-            public void onStopped() {
-                super.onStopped();
-                Timber.d("Local Hotspot Stopped");
-            }
+                @Override
+                public void onStopped() {
+                    super.onStopped();
+                    Timber.d("Local Hotspot Stopped");
+                }
 
-            @Override
-            public void onFailed(int reason) {
-                super.onFailed(reason);
-                Timber.d("Local Hotspot failed to start");
-            }
-        }, new Handler());
+                @Override
+                public void onFailed(int reason) {
+                    super.onFailed(reason);
+                    Timber.d("Local Hotspot failed to start");
+                }
+            }, new Handler());
+        }
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)


### PR DESCRIPTION
Closes #323 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
Checked whether the crash is happening or not while sending the forms for the second time through hotspot transformation 

#### Why is this the best possible solution? Were any other approaches considered?
As we are making local hotspot request once again so, checked whether the hotspot is initiated before we request for hotspot  

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Crash is not the good behavior of the ideal app so, by fixing that user can directly send the forms
for a second time without restarting the app 

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).