### PR TITLE
feat: Add shortcuts on long pressing of app icon

### DIFF
--- a/skunkworks_crow/src/main/AndroidManifest.xml
+++ b/skunkworks_crow/src/main/AndroidManifest.xml
@@ -36,6 +36,8 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
         <activity
             android:name=".views.ui.hotspot.HpReceiverActivity"

--- a/skunkworks_crow/src/main/res/drawable/ic_send_black_24dp.xml
+++ b/skunkworks_crow/src/main/res/drawable/ic_send_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M2.01,21L23,12 2.01,3 2,10l15,2 -15,2z" />
+</vector>

--- a/skunkworks_crow/src/main/res/values/strings.xml
+++ b/skunkworks_crow/src/main/res/values/strings.xml
@@ -130,11 +130,11 @@
 
     <!--App shortcuts-->
     <string name="send_short">Send</string>
-    <string name="send_long">Send forms in skunkworks</string>
+    <string name="send_long">Send forms in skunkworks-crow</string>
     <string name="receive_hotspot_short">Receive-hotspot</string>
-    <string name="receive_hotspot_long">Receive forms through hotspot in skunkworks</string>
+    <string name="receive_hotspot_long">Receive forms through hotspot in skunkworks-crow</string>
     <string name="receive_bluetooth_short">Receive-bluetooth</string>
-    <string name="receive_bluetooth_long">Receive forms through bluetooth in skunkworks</string>
+    <string name="receive_bluetooth_long">Receive forms through bluetooth in skunkworks-crow</string>
 
     <string-array name="stats_field">
         <item name="sent">Sent</item>

--- a/skunkworks_crow/src/main/res/values/strings.xml
+++ b/skunkworks_crow/src/main/res/values/strings.xml
@@ -128,6 +128,14 @@
     <string name="feedback_sent">\nFeedback sent by reviewer: %s</string>
     <string name="no_feedback_sent">\nNo feedback sent by the reviewer</string>
 
+    <!--App shortcuts-->
+    <string name="send_short">Send</string>
+    <string name="send_long">Send forms in skunkworks</string>
+    <string name="receive_hotspot_short">Receive-hotspot</string>
+    <string name="receive_hotspot_long">Receive forms through hotspot in skunkworks</string>
+    <string name="receive_bluetooth_short">Receive-bluetooth</string>
+    <string name="receive_bluetooth_long">Receive forms through bluetooth in skunkworks</string>
+
     <string-array name="stats_field">
         <item name="sent">Sent</item>
         <item name="received">Received</item>

--- a/skunkworks_crow/src/main/res/xml/shortcuts.xml
+++ b/skunkworks_crow/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,45 @@
+<shortcuts xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="send"
+        android:enabled="true"
+        android:icon="@drawable/ic_send_black_24dp"
+        android:shortcutShortLabel="@string/send_short"
+        android:shortcutLongLabel="@string/send_long"
+        android:shortcutDisabledMessage="@string/send_short"
+        tools:targetApi="n_mr1">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.odk.share"
+            android:targetClass="org.odk.share.views.ui.send.SendFormsActivity" />
+        <categories android:name="android.intent.category.DEFAULT" />
+    </shortcut>
+    <shortcut
+        android:shortcutId="receive hotspot"
+        android:enabled="true"
+        android:icon="@drawable/ic_wifi_tethering_black_24dp"
+        android:shortcutShortLabel="@string/receive_hotspot_short"
+        android:shortcutLongLabel="@string/receive_hotspot_long"
+        android:shortcutDisabledMessage="@string/receive_hotspot_short"
+        tools:targetApi="n_mr1">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.odk.share"
+            android:targetClass="org.odk.share.views.ui.hotspot.HpReceiverActivity" />
+        <categories android:name="android.intent.category.DEFAULT" />
+    </shortcut>
+    <shortcut
+        android:shortcutId="receive bluetooth"
+        android:enabled="true"
+        android:icon="@drawable/ic_bluetooth_black_24dp"
+        android:shortcutShortLabel="@string/receive_bluetooth_short"
+        android:shortcutLongLabel="@string/receive_bluetooth_long"
+        android:shortcutDisabledMessage="@string/receive_bluetooth_short"
+        tools:targetApi="n_mr1">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.odk.share"
+            android:targetClass="org.odk.share.views.ui.bluetooth.BtReceiverActivity" />
+        <categories android:name="android.intent.category.DEFAULT" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
Closes #327 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
1. Checked whether it is showing shortcuts in some android devices
- Samsung j8(Android version 9) - ok
- oneplus 6(android 10) -ok
- vivo y55s(android 6)- Not shown (working fine everything no problem)
2. Checked whether every activity is working fine or not

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Added the 3 shortcuts in `shortcuts.xml` file, By adding shortcuts to the app user can directly navigate into the particular section he wants 

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).