### PR TITLE
fixed:Remove hardcoded dimens from xml layout files #326

### DIFF
--- a/skunkworks_crow/src/main/res/layout/about_list_item.xml
+++ b/skunkworks_crow/src/main/res/layout/about_list_item.xml
@@ -1,12 +1,12 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/MatchParentWidth"
     android:orientation="horizontal"
-    android:padding="10dp">
+    android:padding="@dimen/root_layout_padding">
 
     <ImageView
         android:id="@+id/ivIcon"
         style="@style/WrapContent"
-        android:layout_margin="10dp"
+        android:layout_margin="@dimen/image_view_margin"
         android:src="@drawable/ic_stars" />
 
     <TextView

--- a/skunkworks_crow/src/main/res/layout/activity_bt_receive.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_bt_receive.xml
@@ -17,17 +17,17 @@
         android:orientation="vertical">
 
         <ImageView
-            android:layout_width="144dp"
-            android:layout_height="144dp"
+            android:layout_width="@dimen/image_view_width"
+            android:layout_height="@dimen/image_view_height"
             android:layout_gravity="center"
             android:src="@drawable/ic_no_devices_found" />
 
         <TextView
             style="@style/MatchParentWidth"
-            android:layout_marginTop="24dp"
+            android:layout_marginTop="@dimen/text_view_margin_top"
             android:gravity="center"
             android:text="@string/bluetooth_no_device_scanned"
-            android:textSize="22sp" />
+            android:textSize="@dimen/text_view_primary_text_size" />
 
     </LinearLayout>
 
@@ -41,8 +41,8 @@
         android:id="@+id/btn_refresh"
         style="@style/MatchParentWidth"
         android:layout_alignParentBottom="true"
-        android:layout_margin="4dp"
+        android:layout_margin="@dimen/button_margin"
         android:text="@string/btn_refresh"
-        android:textSize="15sp" />
+        android:textSize="@dimen/button_text_size" />
 
 </RelativeLayout>

--- a/skunkworks_crow/src/main/res/layout/activity_bt_send.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_bt_send.xml
@@ -15,24 +15,24 @@
         <ImageView
             android:id="@+id/bluetooth_icon"
             android:layout_width="match_parent"
-            android:layout_height="144dp"
+            android:layout_height="@dimen/image_view_height"
             android:src="@drawable/ic_bluetooth_logo" />
 
         <ProgressBar
             android:id="@+id/progressBar"
             style="@style/HorizontalProgressBar"
-            android:layout_width="244dp"
+            android:layout_width="@dimen/progressbar_width"
             android:layout_height="wrap_content"
-            android:layout_marginTop="28dp"
+            android:layout_marginTop="@dimen/progressbar_margin_top_minimal"
             android:indeterminate="true" />
 
         <TextView
             android:id="@+id/test_text_view"
             style="@style/MatchParentWidth"
             android:layout_gravity="center"
-            android:layout_marginTop="28dp"
+            android:layout_marginTop="@dimen/text_view_margin_top"
             android:gravity="center"
-            android:textSize="20sp"
+            android:textSize="@dimen/text_view_primary_text_size"
             tools:text="@string/tv_sender_wait_for_connect" />
     </LinearLayout>
 

--- a/skunkworks_crow/src/main/res/layout/activity_instance_manager_tabs.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_instance_manager_tabs.xml
@@ -16,7 +16,7 @@
             style="@style/MatchParentWidth"
             app:tabGravity="fill"
             app:tabIndicatorColor="@android:color/white"
-            app:tabMaxWidth="0dp"
+            app:tabMaxWidth="@dimen/tab_max_width"
             app:tabMode="fixed" />
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/skunkworks_crow/src/main/res/layout/activity_instances_list.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_instances_list.xml
@@ -28,10 +28,10 @@
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
-            android:padding="12dp"
+            android:padding="@dimen/button_padding"
             android:text="@string/select_all"
             android:textAllCaps="false"
-            android:textSize="16sp" />
+            android:textSize="@dimen/button_text_size" />
 
         <Button
             android:id="@+id/send_button"
@@ -39,9 +39,9 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:enabled="false"
-            android:padding="12dp"
+            android:padding="@dimen/button_padding"
             android:text="@string/send_selected"
             android:textAllCaps="false"
-            android:textSize="16sp" />
+            android:textSize="@dimen/button_text_size" />
     </LinearLayout>
 </RelativeLayout>

--- a/skunkworks_crow/src/main/res/layout/activity_main.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_main.xml
@@ -18,8 +18,8 @@
             android:layout_centerHorizontal="true"
             android:layout_centerVertical="true"
             android:gravity="center"
-            android:padding="10dp"
-            android:textSize="22sp" />
+            android:padding="@dimen/text_view_padding"
+            android:textSize="@dimen/text_view_primary_text_size" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerview"

--- a/skunkworks_crow/src/main/res/layout/activity_review_form.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_review_form.xml
@@ -15,7 +15,7 @@
         <LinearLayout
             style="@style/MatchParentWidth"
             android:orientation="vertical"
-            android:padding="10dp">
+            android:padding="@dimen/linear_layout_padding">
 
             <View
                 style="@style/MatchParentWidth"
@@ -27,10 +27,10 @@
                 android:layout_gravity="center"
                 android:gravity="center"
                 android:lineSpacingMultiplier="1.2"
-                android:paddingTop="10dp"
-                android:paddingBottom="20dp"
+                android:paddingTop="@dimen/text_view_padding_top"
+                android:paddingBottom="@dimen/text_view_padding_bottom"
                 android:textColor="@color/colorPrimary"
-                android:textSize="21sp"
+                android:textSize="@dimen/text_view_primary_text_size"
                 android:textStyle="bold" />
 
             <com.google.android.material.textfield.TextInputLayout
@@ -42,7 +42,7 @@
                     style="@style/MatchParentWidth"
                     android:hint="@string/add_feedback"
                     android:inputType="text"
-                    android:textSize="18sp"
+                    android:textSize="@dimen/edit_text_text_size"
                     tools:ignore="Autofill" />
 
             </com.google.android.material.textfield.TextInputLayout>

--- a/skunkworks_crow/src/main/res/layout/activity_send.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_send.xml
@@ -9,10 +9,10 @@
         android:id="@+id/tvConnectStatus"
         style="@style/MatchParentWidth"
         android:layout_below="@id/toolbar"
-        android:layout_margin="10dp"
+        android:layout_margin="@dimen/text_view_margin"
         android:gravity="center"
         android:text="@string/waiting_hotspot"
-        android:textSize="20sp" />
+        android:textSize="@dimen/text_view_primary_text_size" />
 
     <ImageView
         android:id="@+id/ivQRcode"
@@ -25,8 +25,8 @@
         android:id="@+id/tvConnectInfo"
         style="@style/MatchParentWidth"
         android:layout_alignParentBottom="true"
-        android:layout_margin="10dp"
+        android:layout_margin="@dimen/text_view_margin"
         android:gravity="center"
-        android:paddingBottom="20dp"
-        android:textSize="16sp" />
+        android:paddingBottom="@dimen/text_view_padding_bottom"
+        android:textSize="@dimen/text_view_secondary_text_size" />
 </RelativeLayout>

--- a/skunkworks_crow/src/main/res/layout/activity_web_view.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_web_view.xml
@@ -1,11 +1,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/MatchParent"
-    android:layout_marginLeft="0dp"
-    android:layout_marginTop="0dp"
-    android:layout_marginRight="0dp"
-    android:layout_marginBottom="0dp"
+    android:layout_margin="@dimen/webView_root_layout_margin"
     android:orientation="vertical"
-    android:padding="0dp">
+    android:padding="@dimen/webView_root_layout_padding">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"

--- a/skunkworks_crow/src/main/res/layout/activity_wifi.xml
+++ b/skunkworks_crow/src/main/res/layout/activity_wifi.xml
@@ -23,15 +23,15 @@
             android:layout_centerHorizontal="true"
             android:layout_centerVertical="true"
             android:gravity="center"
-            android:padding="10dp"
+            android:padding="@dimen/text_view_padding"
             android:text="@string/no_wifi_available"
-            android:textSize="22sp" />
+            android:textSize="@dimen/text_view_primary_text_size" />
 
         <ProgressBar
             android:id="@+id/wifi_progress_bar"
             style="@style/WrapContent"
             android:layout_centerHorizontal="true"
-            android:layout_marginTop="128dp" />
+            android:layout_marginTop="@dimen/progressbar_margin_top" />
 
     </RelativeLayout>
 

--- a/skunkworks_crow/src/main/res/layout/bottom_sheet.xml
+++ b/skunkworks_crow/src/main/res/layout/bottom_sheet.xml
@@ -18,14 +18,14 @@ the License.
     xmlns:app="http://schemas.android.com/apk/res-auto"
     style="@style/MatchParentWidth"
     android:orientation="vertical"
-    android:padding="16dp"
+    android:padding="@dimen/root_layout_padding"
     app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
 
     <TextView
         android:id="@+id/label"
         style="@style/MatchParentWidth"
         android:layout_alignParentTop="true"
-        android:layout_marginBottom="8dp"
+        android:layout_marginBottom="@dimen/text_view_margin_bottom"
         android:text="@string/sort_by"
         android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium" />
 

--- a/skunkworks_crow/src/main/res/layout/dialog_password.xml
+++ b/skunkworks_crow/src/main/res/layout/dialog_password.xml
@@ -5,9 +5,9 @@
     <EditText
         android:id="@+id/etPassword"
         style="@style/MatchParentWidth"
-        android:layout_marginLeft="10dp"
-        android:layout_marginTop="5dp"
-        android:layout_marginRight="10dp"
+        android:layout_marginLeft="@dimen/edit_text_margin_left"
+        android:layout_marginTop="@dimen/edit_text_margin_top"
+        android:layout_marginRight="@dimen/edit_text_margin_right"
         android:inputType="textPassword" />
 
     <CheckBox

--- a/skunkworks_crow/src/main/res/layout/dialog_password.xml
+++ b/skunkworks_crow/src/main/res/layout/dialog_password.xml
@@ -6,8 +6,10 @@
         android:id="@+id/etPassword"
         style="@style/MatchParentWidth"
         android:layout_marginLeft="@dimen/edit_text_margin_left"
+        android:layout_marginStart="@dimen/edit_text_margin_left"
         android:layout_marginTop="@dimen/edit_text_margin_top"
         android:layout_marginRight="@dimen/edit_text_margin_right"
+        android:layout_marginEnd="@dimen/edit_text_margin_right"
         android:inputType="textPassword" />
 
     <CheckBox

--- a/skunkworks_crow/src/main/res/layout/dialog_password_til.xml
+++ b/skunkworks_crow/src/main/res/layout/dialog_password_til.xml
@@ -2,8 +2,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/et_password_layout"
     style="@style/MatchParentWidth"
-    android:paddingLeft="16dp"
-    android:paddingRight="16dp"
+    android:paddingLeft="@dimen/root_layout_padding"
+    android:paddingRight="@dimen/root_layout_padding"
     app:passwordToggleEnabled="true">
 
     <com.google.android.material.textfield.TextInputEditText

--- a/skunkworks_crow/src/main/res/layout/fragment_forms.xml
+++ b/skunkworks_crow/src/main/res/layout/fragment_forms.xml
@@ -9,8 +9,8 @@
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:gravity="center"
-        android:padding="10dp"
-        android:textSize="22sp" />
+        android:padding="@dimen/text_view_padding"
+        android:textSize="@dimen/text_view_primary_text_size" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerview"
@@ -29,10 +29,10 @@
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
-            android:padding="12dp"
+            android:padding="@dimen/button_padding"
             android:text="@string/select_all"
             android:textAllCaps="false"
-            android:textSize="16sp" />
+            android:textSize="@dimen/button_text_size" />
 
         <Button
             android:id="@+id/send_button"
@@ -40,10 +40,10 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:enabled="false"
-            android:padding="12dp"
+            android:padding="@dimen/button_padding"
             android:text="@string/send_selected"
             android:textAllCaps="false"
-            android:textSize="16sp" />
+            android:textSize="@dimen/button_text_size" />
     </LinearLayout>
 
 </RelativeLayout>

--- a/skunkworks_crow/src/main/res/layout/fragment_instances.xml
+++ b/skunkworks_crow/src/main/res/layout/fragment_instances.xml
@@ -9,8 +9,8 @@
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:gravity="center"
-        android:padding="10dp"
-        android:textSize="22sp" />
+        android:padding="@dimen/text_view_padding"
+        android:textSize="@dimen/text_view_primary_text_size" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerview"

--- a/skunkworks_crow/src/main/res/layout/fragment_stats.xml
+++ b/skunkworks_crow/src/main/res/layout/fragment_stats.xml
@@ -5,7 +5,7 @@
     <LinearLayout
         style="@style/MatchParentWidth"
         android:orientation="vertical"
-        android:padding="10dp">
+        android:padding="@dimen/linear_layout_padding">
 
         <View
             style="@style/MatchParentWidth"
@@ -16,9 +16,9 @@
             style="@style/WrapContent"
             android:layout_gravity="center"
             android:gravity="center"
-            android:paddingTop="10dp"
+            android:paddingTop="@dimen/text_view_padding_top"
             android:textColor="@color/colorPrimary"
-            android:textSize="21sp"
+            android:textSize="@dimen/text_view_primary_text_size"
             android:textStyle="bold" />
 
         <TextView
@@ -26,14 +26,14 @@
             style="@style/WrapContent"
             android:layout_gravity="center"
             android:gravity="center"
-            android:paddingBottom="20dp"
+            android:paddingBottom="@dimen/text_view_padding_bottom"
             android:textColor="@color/colorPrimary"
-            android:textSize="18sp" />
+            android:textSize="@dimen/text_view_secondary_text_size" />
 
         <com.github.mikephil.charting.charts.BarChart
             android:id="@+id/chart"
-            android:layout_width="362dp"
-            android:layout_height="184dp"
+            android:layout_width="@dimen/bar_chart_width"
+            android:layout_height="@dimen/bar_chart_height"
             android:layout_gravity="center" />
 
         <View

--- a/skunkworks_crow/src/main/res/layout/list_item_bt_device.xml
+++ b/skunkworks_crow/src/main/res/layout/list_item_bt_device.xml
@@ -9,9 +9,9 @@
 
     <ImageView
         android:id="@+id/iv_device"
-        android:layout_width="72dp"
-        android:layout_height="72dp"
-        android:padding="12dp"
+        android:layout_width="@dimen/element_image_view_width"
+        android:layout_height="@dimen/element_image_view_height"
+        android:padding="@dimen/image_view_padding"
         android:src="@drawable/ic_smart_phone_black" />
 
     <LinearLayout
@@ -21,23 +21,23 @@
         <TextView
             android:id="@+id/tv_device_name"
             style="@style/MatchParentWidth"
-            android:layout_marginStart="6dp"
-            android:layout_marginLeft="6dp"
-            android:layout_marginTop="10dp"
-            android:layout_marginBottom="4dp"
+            android:layout_marginStart="@dimen/text_view_margin_start"
+            android:layout_marginLeft="@dimen/text_view_secondary_margin_left"
+            android:layout_marginTop="@dimen/text_view_margin_top_minimal"
+            android:layout_marginBottom="@dimen/text_view_margin_bottom_minimal"
             android:gravity="center_vertical"
             android:text="@string/bluetooth_instance_name_default"
-            android:textSize="16sp" />
+            android:textSize="@dimen/text_view_secondary_text_size" />
 
         <TextView
             android:id="@+id/tv_device_address"
             style="@style/MatchParent"
-            android:layout_marginStart="6dp"
-            android:layout_marginLeft="6dp"
-            android:layout_marginTop="2dp"
-            android:layout_marginBottom="2dp"
+            android:layout_marginStart="@dimen/text_view_secondary_margin_start"
+            android:layout_marginLeft="@dimen/text_view_secondary_margin_left"
+            android:layout_marginTop="@dimen/text_view_secondary_margin_top"
+            android:layout_marginBottom="@dimen/text_view_secondary_margin_bottom"
             android:gravity="center_vertical"
-            android:textSize="12sp"
+            android:textSize="@dimen/text_view_minimal_text_size"
             tools:text="default device address" />
     </LinearLayout>
 </LinearLayout>

--- a/skunkworks_crow/src/main/res/layout/list_item_checkbox.xml
+++ b/skunkworks_crow/src/main/res/layout/list_item_checkbox.xml
@@ -6,15 +6,15 @@
     <ImageView
         android:id="@+id/iconfilledform"
         style="@style/MatchParentHeight"
-        android:paddingStart="6dp"
-        android:paddingLeft="6dp"
-        android:paddingEnd="6dp"
-        android:paddingRight="6dp"
+        android:paddingStart="@dimen/image_view_padding_start"
+        android:paddingLeft="@dimen/image_view_padding_left"
+        android:paddingEnd="@dimen/image_view_padding_end"
+        android:paddingRight="@dimen/image_view_padding_right"
         android:src="@drawable/ic_assignment_black_24dp" />
 
     <RelativeLayout
         style="@style/MatchParentWidth"
-        android:padding="8dp">
+        android:padding="@dimen/relative_layout_padding">
 
 
         <TextView
@@ -57,8 +57,8 @@
             android:id="@+id/tvReviewForm"
             style="@style/WrapContent"
             android:layout_below="@id/tvSubtitle"
-            android:layout_marginEnd="10dp"
-            android:layout_marginRight="10dp" />
+            android:layout_marginEnd="@dimen/text_view_margin_end"
+            android:layout_marginRight="@dimen/text_view_margin_right_minimal" />
 
         <TextView
             android:id="@+id/tvUnReviewForm"

--- a/skunkworks_crow/src/main/res/layout/list_item_checkbox.xml
+++ b/skunkworks_crow/src/main/res/layout/list_item_checkbox.xml
@@ -6,10 +6,10 @@
     <ImageView
         android:id="@+id/iconfilledform"
         style="@style/MatchParentHeight"
-        android:paddingStart="@dimen/image_view_padding_start"
-        android:paddingLeft="@dimen/image_view_padding_left"
-        android:paddingEnd="@dimen/image_view_padding_end"
-        android:paddingRight="@dimen/image_view_padding_right"
+        android:paddingStart="@dimen/image_view_padding_small"
+        android:paddingLeft="@dimen/image_view_padding_small"
+        android:paddingEnd="@dimen/image_view_padding_small"
+        android:paddingRight="@dimen/image_view_padding_small"
         android:src="@drawable/ic_assignment_black_24dp" />
 
     <RelativeLayout

--- a/skunkworks_crow/src/main/res/layout/list_item_single.xml
+++ b/skunkworks_crow/src/main/res/layout/list_item_single.xml
@@ -1,6 +1,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/MatchParentWidth"
-    android:padding="10dp">
+    android:padding="@dimen/linear_layout_padding">
 
     <TextView
         android:id="@+id/tvTitle"

--- a/skunkworks_crow/src/main/res/layout/sort_item_layout.xml
+++ b/skunkworks_crow/src/main/res/layout/sort_item_layout.xml
@@ -21,8 +21,8 @@ the License.
     android:focusable="true"
     android:foreground="?android:attr/selectableItemBackground"
     android:orientation="horizontal"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp">
+    android:paddingTop="@dimen/root_layout_padding_top"
+    android:paddingBottom="@dimen/root_layout_padding_bottom">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/icon"
@@ -33,8 +33,8 @@ the License.
         android:id="@+id/title"
         style="@style/WrapContent"
         android:layout_gravity="center"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
+        android:layout_marginLeft="@dimen/text_view_margin_left"
+        android:layout_marginRight="@dimen/text_view_margin_right"
         android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
         tools:text="Sort by Name" />
 </LinearLayout>

--- a/skunkworks_crow/src/main/res/layout/sort_item_layout.xml
+++ b/skunkworks_crow/src/main/res/layout/sort_item_layout.xml
@@ -34,7 +34,11 @@ the License.
         style="@style/WrapContent"
         android:layout_gravity="center"
         android:layout_marginLeft="@dimen/text_view_margin_left"
+        android:layout_marginStart="@dimen/text_view_margin_left"
         android:layout_marginRight="@dimen/text_view_margin_right"
+
+        android:layout_marginEnd="@dimen/text_view_margin_right"
+
         android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
         tools:text="Sort by Name" />
 </LinearLayout>

--- a/skunkworks_crow/src/main/res/layout/toolbar.xml
+++ b/skunkworks_crow/src/main/res/layout/toolbar.xml
@@ -6,8 +6,8 @@
     android:layout_height="?attr/actionBarSize"
     android:background="?attr/colorPrimary"
     android:minHeight="?attr/actionBarSize"
-    app:contentInsetEnd="0dp"
-    app:contentInsetStart="12dp"
-    app:contentInsetStartWithNavigation="0dp"
+    app:contentInsetEnd="@dimen/content_inset_end"
+    app:contentInsetStart="@dimen/content_inset_start"
+    app:contentInsetStartWithNavigation="@dimen/content_inset_start_with_navigation"
     app:titleTextColor="@android:color/white"
     app:theme="@style/AppTheme.ActionBar" />

--- a/skunkworks_crow/src/main/res/values/dimens.xml
+++ b/skunkworks_crow/src/main/res/values/dimens.xml
@@ -21,12 +21,7 @@
     <dimen name="image_view_width">144dp</dimen>
     <dimen name="image_view_padding">12dp</dimen>
 
-    <dimen name="image_view_padding_start">6dp</dimen>
-    <dimen name="image_view_padding_left">6dp</dimen>
-    <dimen name="image_view_padding_end">6dp</dimen>
-    <dimen name="image_view_padding_right">6dp</dimen>
-
-
+    <dimen name="image_view_padding_small">6dp</dimen>
 
     <dimen name="element_image_view_height">72dp</dimen>
     <dimen name="element_image_view_width">72dp</dimen>

--- a/skunkworks_crow/src/main/res/values/dimens.xml
+++ b/skunkworks_crow/src/main/res/values/dimens.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+<!-- Common dimensions for all layout files-->
+
+<!--Layout dimens-->
+    <dimen name="linear_layout_padding">10dp</dimen>
+    <dimen name="root_layout_padding">16dp</dimen>
+    <dimen name="root_layout_padding_top">8dp</dimen>
+    <dimen name="root_layout_padding_bottom">8dp</dimen>
+
+    <dimen name="relative_layout_padding">8dp</dimen>
+
+    <dimen name="webView_root_layout_margin">0dp</dimen>
+    <dimen name="webView_root_layout_padding">0dp</dimen>
+
+
+    <!--image view dimens-->
+    <dimen name="image_view_margin">10dp</dimen>
+    <dimen name="image_view_height">144dp</dimen>
+    <dimen name="image_view_width">144dp</dimen>
+    <dimen name="image_view_padding">12dp</dimen>
+
+    <dimen name="image_view_padding_start">6dp</dimen>
+    <dimen name="image_view_padding_left">6dp</dimen>
+    <dimen name="image_view_padding_end">6dp</dimen>
+    <dimen name="image_view_padding_right">6dp</dimen>
+
+
+
+    <dimen name="element_image_view_height">72dp</dimen>
+    <dimen name="element_image_view_width">72dp</dimen>
+
+<!--text view dimens-->
+    <!--text view text size dimens-->
+    <dimen name="text_view_primary_text_size">21sp</dimen>
+    <dimen name="text_view_secondary_text_size">17sp</dimen>
+    <dimen name="text_view_minimal_text_size">12sp</dimen>
+
+    <!--text view margin dimens-->
+
+    <dimen name="text_view_margin_top">26dp</dimen>
+    <dimen name="text_view_margin">10dp</dimen>
+    <dimen name="text_view_margin_bottom">8dp</dimen>
+    <dimen name="text_view_margin_top_minimal">10dp</dimen>
+    <dimen name="text_view_margin_start">6dp</dimen>
+    <dimen name="text_view_margin_bottom_minimal">4dp</dimen>
+    <dimen name="text_view_margin_left_minimal">6dp</dimen>
+    <dimen name="text_view_margin_end">10dp</dimen>
+    <dimen name="text_view_margin_right_minimal">10dp</dimen>
+    <dimen name="text_view_margin_left">16dp</dimen>
+    <dimen name="text_view_margin_right">16dp</dimen>
+
+   <!--text view(secondary) margin dimens-->
+
+    <dimen name="text_view_secondary_margin_start">6dp</dimen>
+    <dimen name="text_view_secondary_margin_left">6dp</dimen>
+    <dimen name="text_view_secondary_margin_top">2dp</dimen>
+    <dimen name="text_view_secondary_margin_bottom">2dp</dimen>
+
+   <!--text view padding dimens-->
+    <dimen name="text_view_padding">10dp</dimen>
+    <dimen name="text_view_padding_top">10dp</dimen>
+    <dimen name="text_view_padding_bottom">20dp</dimen>
+
+
+<!--Button dimens-->
+
+    <dimen name="button_margin">4dp</dimen>
+    <dimen name="button_padding">12dp</dimen>
+    <dimen name="button_text_size">16sp</dimen>
+
+
+<!--progressbar dimens-->
+    <dimen name="progressbar_width">244dp</dimen>
+    <dimen name="progressbar_margin_top_minimal">28dp</dimen>
+    <dimen name="progressbar_margin_top">128dp</dimen>
+
+
+    <!--tab dimens-->
+    <dimen name="tab_max_width">0dp</dimen>
+
+<!--edit text dimens-->
+    <dimen name="edit_text_text_size">18sp</dimen>
+    <dimen name="edit_text_margin_left">10dp</dimen>
+    <dimen name="edit_text_margin_right">10dp</dimen>
+    <dimen name="edit_text_margin_top">5dp</dimen>
+
+
+
+  <!--Chart dimensions-->
+
+    <dimen name="bar_chart_height">184dp</dimen>
+    <dimen name="bar_chart_width">362dp</dimen>
+
+
+<!--toolbar dimens-->
+    <dimen name="content_inset_end">0dp</dimen>
+    <dimen name="content_inset_start">12dp</dimen>
+    <dimen name="content_inset_start_with_navigation">0dp</dimen>
+
+
+</resources>


### PR DESCRIPTION
Move hardcoded dimension(ex: 16dp) to dimens.xml file

Closes #326 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I ran the application on my phone(One Plus 6T Android 9.0) and it worked perfectly fine

#### Why is this the best possible solution? Were any other approaches considered?
 Here, I added dimens.xml file and moved all hardcoded dimensions  to dimens.xml file


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Now It will be easy to standardize dimensions of all the dimensions like height, width, text size, etc.



#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).