### PR TITLE
Updated Checkstyle plugin to the latest 8.28 version

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -64,9 +64,7 @@
                 value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH, LITERAL_CATCH, LITERAL_WHILE" />
         </module>
         <module name="NeedBraces" />
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="100" />
-        </module>
+        <module name="LeftCurly" />
         <module name="RightCurly">
             <property name="id" value="RightCurlySame" />
             <property name="tokens"

--- a/config/quality.gradle
+++ b/config/quality.gradle
@@ -21,7 +21,7 @@ def reportsDir = "${project.buildDir}/reports"
 
 apply plugin: 'checkstyle'
 
-checkstyle.toolVersion = '7.6.1'
+checkstyle.toolVersion = '8.28'
 
 task checkstyle(type: Checkstyle) {
     configFile file("$configDir/checkstyle.xml")

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/BlankFormsFragment.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/BlankFormsFragment.java
@@ -75,7 +75,8 @@ public class BlankFormsFragment extends FormListFragment implements LoaderManage
     private LinkedHashSet<Long> selectedForms;
 
 
-    public BlankFormsFragment() { }
+    public BlankFormsFragment() {
+    }
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -124,7 +125,8 @@ public class BlankFormsFragment extends FormListFragment implements LoaderManage
 
 
     @Override
-    public void onLoaderReset(@NonNull Loader loader) { }
+    public void onLoaderReset(@NonNull Loader loader) {
+    }
 
     @Override
     public void onItemClick(BaseCursorViewHolder holder, int position) {

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/FilledFormsFragment.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/FilledFormsFragment.java
@@ -64,7 +64,8 @@ public class FilledFormsFragment extends InstanceListFragment implements LoaderM
     private InstanceAdapter instanceAdapter;
     private LinkedHashSet<Long> selectedInstances;
 
-    public FilledFormsFragment() { }
+    public FilledFormsFragment() {
+    }
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
@@ -114,7 +115,8 @@ public class FilledFormsFragment extends InstanceListFragment implements LoaderM
 
 
     @Override
-    public void onLoaderReset(@NonNull Loader loader) { }
+    public void onLoaderReset(@NonNull Loader loader) {
+    }
 
     private void onListItemClick(View view, int position) {
         Cursor cursor = instanceAdapter.getCursor();


### PR DESCRIPTION
…yCheck

Closes #192 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I tested it by running `./gradlew checkstyle`

#### Why is this the best possible solution? Were any other approaches considered?
I updated the `checkstyle.toolVersion` to the latest version in `quality.gradle` file. I removed the property `maxLineLength` of `LeftCurlyCheck`, as it had been deprecated in [checkstyle release 8.2.](https://checkstyle.sourceforge.io/releasenotes.html)
And I made minor changes to prevent checkstyle rule violations, in accordance with the latest version.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No, I think there are no regression risks.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).