### PR TITLE
fix: using app without odk collect installed

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
@@ -60,6 +60,7 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
     private static final String FORM_CHOOSER_LIST_SORTING_ORDER = "formChooserListSortingOrder";
     private static final String COLLECT_PACKAGE = "org.odk.collect.android";
     private static final int STORAGE_PERMISSION_REQUEST_CODE = 101;
+    private static final int COLLECT_INSTALL_REQUEST_CODE = 102;
     private static final int FORM_LOADER = 2;
 
     @BindView(R.id.toolbar)
@@ -213,9 +214,12 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
 
         builder.setPositiveButton(getString(R.string.install), (DialogInterface dialog, int which) -> {
             try {
-                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + COLLECT_PACKAGE)));
+                startActivityForResult(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + COLLECT_PACKAGE)),
+                        COLLECT_INSTALL_REQUEST_CODE);
             } catch (ActivityNotFoundException e) {
-                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=" + COLLECT_PACKAGE)));
+                startActivityForResult(new Intent(Intent.ACTION_VIEW,
+                                Uri.parse("https://play.google.com/store/apps/details?id=" + COLLECT_PACKAGE)),
+                        COLLECT_INSTALL_REQUEST_CODE);
             }
         });
 
@@ -274,6 +278,11 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
                     != PackageManager.PERMISSION_GRANTED) {
                 PermissionUtils.showAppInfo(this, getPackageName(), getString(R.string.permission_open_storage_info), getString(R.string.permission_storage_denied));
             } else {
+                setUpLoader();
+            }
+        }
+        if (requestCode == COLLECT_INSTALL_REQUEST_CODE) {
+            if(!isCollectInstalled()) {
                 setUpLoader();
             }
         }


### PR DESCRIPTION
Closes #337 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
Verified by testing on Vivo Z1 Pro running on Android v9.x.x
#### Why is this the best possible solution? Were any other approaches considered?
NA
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It restricts the user from using the app without installing ODK collect app.
#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).