### PR TITLE
feat: long press on filled forms navigate to ODK collect

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/injection/config/AppModule.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/injection/config/AppModule.java
@@ -15,6 +15,7 @@ import org.odk.share.rx.schedulers.BaseSchedulerProvider;
 import org.odk.share.rx.schedulers.SchedulerProvider;
 import org.odk.share.services.ReceiverService;
 import org.odk.share.services.SenderService;
+import org.odk.share.views.customui.LaunchCollect;
 
 import dagger.Module;
 import dagger.Provides;
@@ -65,6 +66,11 @@ class AppModule {
     @Provides
     TransferDao provideTransferDao(Context context) {
         return new TransferDao(context);
+    }
+
+    @Provides
+    LaunchCollect provideLaunchCollect(Context context) {
+        return new LaunchCollect(context);
     }
 
     @Provides

--- a/skunkworks_crow/src/main/java/org/odk/share/views/customui/LaunchCollect.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/customui/LaunchCollect.java
@@ -1,0 +1,35 @@
+package org.odk.share.views.customui;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.widget.Toast;
+
+import org.odk.share.R;
+
+/**
+ * @author by Chromicle (ajayprabhakar369@gmail.com)
+ * @since 1/21/2020
+ */
+
+
+public class LaunchCollect {
+    private Context context;
+
+    public LaunchCollect(Context context) {
+        this.context = context;
+    }
+
+    public void openFormInCollect(long instanceId) {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse("content://org.odk.collect.android.provider.odk.instances/instances/" + instanceId));
+        intent.putExtra("formMode", "viewSent");
+        if (intent.resolveActivity(context.getPackageManager()) == null) {
+            Toast.makeText(context, context.getString(R.string.collect_not_installed), Toast.LENGTH_LONG).show();
+        } else {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            context.startActivity(intent);
+        }
+    }
+
+}

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/instance/adapter/InstanceAdapter.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/instance/adapter/InstanceAdapter.java
@@ -8,16 +8,18 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
 import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.share.R;
+import org.odk.share.views.customui.LaunchCollect;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import timber.log.Timber;
@@ -32,6 +34,7 @@ public class InstanceAdapter extends RecyclerView.Adapter<InstanceAdapter.Instan
     private Context context;
     private final OnItemClickListener listener;
     private LinkedHashSet<Long> selectedInstances;
+
 
     public InstanceAdapter(Context context, Cursor cursor, OnItemClickListener listener,
                            LinkedHashSet<Long> selectedInstances) {
@@ -69,7 +72,13 @@ public class InstanceAdapter extends RecyclerView.Adapter<InstanceAdapter.Instan
         holder.reviewedForms.setVisibility(View.GONE);
         holder.unReviewedForms.setVisibility(View.GONE);
 
+        holder.itemView.setOnLongClickListener(view -> {
+            LaunchCollect launchCollect = new LaunchCollect(context);
+            launchCollect.openFormInCollect(id);
+            return true;
+        });
     }
+
 
     public static String getDisplaySubtext(Context context, String state, Date date) {
         try {
@@ -105,7 +114,6 @@ public class InstanceAdapter extends RecyclerView.Adapter<InstanceAdapter.Instan
     }
 
 
-
     public Cursor getCursor() {
         return cursor;
     }
@@ -116,9 +124,12 @@ public class InstanceAdapter extends RecyclerView.Adapter<InstanceAdapter.Instan
 
     static class InstanceHolder extends RecyclerView.ViewHolder {
 
-        @BindView(R.id.tvTitle) public TextView title;
-        @BindView(R.id.tvSubtitle) public TextView subtitle;
-        @BindView(R.id.checkbox) public CheckBox checkBox;
+        @BindView(R.id.tvTitle)
+        public TextView title;
+        @BindView(R.id.tvSubtitle)
+        public TextView subtitle;
+        @BindView(R.id.checkbox)
+        public CheckBox checkBox;
         @BindView(R.id.tvReviewForm)
         TextView reviewedForms;
         @BindView(R.id.tvUnReviewForm)

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/review/ReviewFormActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/review/ReviewFormActivity.java
@@ -1,9 +1,7 @@
 package org.odk.share.views.ui.review;
 
 import android.content.ContentValues;
-import android.content.Intent;
 import android.database.Cursor;
-import android.net.Uri;
 import android.os.Bundle;
 import android.widget.Button;
 import android.widget.EditText;
@@ -17,6 +15,7 @@ import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.share.R;
 import org.odk.share.dao.TransferDao;
 import org.odk.share.dto.TransferInstance;
+import org.odk.share.views.customui.LaunchCollect;
 import org.odk.share.views.ui.common.injectable.InjectableActivity;
 
 import javax.inject.Inject;
@@ -50,6 +49,9 @@ public class ReviewFormActivity extends InjectableActivity {
     @Inject
     TransferDao transferDao;
 
+    @Inject
+    LaunchCollect launchCollect;
+
     public static final String TRANSFER_ID = "transfer_id";
     public static final String INSTANCE_ID = "instance_id";
 
@@ -70,7 +72,7 @@ public class ReviewFormActivity extends InjectableActivity {
         instanceID = getIntent().getLongExtra(INSTANCE_ID, -1);
 
         if (transferID == -1 || instanceID == -1) {
-           finish();
+            finish();
         }
 
         Cursor cursor = transferDao.getInstanceCursorFromId(transferID);
@@ -110,16 +112,6 @@ public class ReviewFormActivity extends InjectableActivity {
         super.onResume();
     }
 
-    private void launchCollect() {
-        Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setData(Uri.parse("content://org.odk.collect.android.provider.odk.instances/instances/" + instanceID));
-        intent.putExtra("formMode", "viewSent");
-        if (intent.resolveActivity(getPackageManager()) == null) {
-            Toast.makeText(this, getString(R.string.collect_not_installed), Toast.LENGTH_LONG).show();
-        } else {
-            startActivity(intent);
-        }
-    }
 
     @OnClick(R.id.bApprove)
     public void acceptForm() {
@@ -185,6 +177,7 @@ public class ReviewFormActivity extends InjectableActivity {
                 String.valueOf(transferID)
         };
         transferDao.updateInstance(values, where, whereArgs);
-        launchCollect();
+        launchCollect.openFormInCollect(instanceID);
     }
+
 }


### PR DESCRIPTION
Closes #343 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?

-  Checked whether collect launching as expected to a particular form by long pressing
-  Checked whether collect is launching as expected while reviewing the forms
-  Checked when we open the form in collect the selected forms are got unselected or not, they are working as expected
-  Checked the device by changing the orientation 
-  Checked transferring forms working perfectly or not with this changes 

#### Why is this the best possible solution? Were any other approaches considered?

I removed the existing method to launch collect and wrote new class `LaunchCollect` in that I gave the method `openFormInCollect` to launch collect as we are using the same method in both the classes and I used the dependency injection for the same 

#### How does this change affect users? 

If user wants to check the form before he starts transforming he has to go the collect and check the form by, adding this feature user can directly check/review the form by long pressing the particular form

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).