### PR TITLE
Add Scatter Chart to statistics fragment

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/instance/fragment/StatisticsFragment.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/instance/fragment/StatisticsFragment.java
@@ -9,12 +9,21 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.github.mikephil.charting.charts.BarChart;
+import com.github.mikephil.charting.charts.ScatterChart;
+import com.github.mikephil.charting.components.AxisBase;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.data.BarData;
 import com.github.mikephil.charting.data.BarDataSet;
 import com.github.mikephil.charting.data.BarEntry;
+import com.github.mikephil.charting.data.DataSet;
+import com.github.mikephil.charting.data.Entry;
+import com.github.mikephil.charting.data.ScatterData;
+import com.github.mikephil.charting.data.ScatterDataSet;
+import com.github.mikephil.charting.formatter.IAxisValueFormatter;
 import com.github.mikephil.charting.formatter.LargeValueFormatter;
+import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.utils.ColorTemplate;
 
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.dto.Instance;
@@ -24,9 +33,15 @@ import org.odk.share.dao.TransferDao;
 import org.odk.share.dto.TransferInstance;
 import org.odk.share.views.ui.common.injectable.InjectableFragment;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -50,6 +65,8 @@ public class StatisticsFragment extends InjectableFragment {
     TextView subtitle;
     @BindView(R.id.chart)
     BarChart chart;
+    @BindView(R.id.detailed_chart)
+    ScatterChart detail_chart;
 
     @Inject
     InstancesDao instancesDao;
@@ -105,30 +122,53 @@ public class StatisticsFragment extends InjectableFragment {
         Cursor transferCursor = transferDao.getSentInstancesCursor();
         List<TransferInstance> transferInstances = transferDao.getInstancesFromCursor(transferCursor);
         int sentCount = 0;
+        HashMap<Long, Integer> sentDates = new HashMap<>();
         for (TransferInstance instance : transferInstances) {
             if (instanceMap.containsKey(instance.getInstanceId())) {
                 sentCount++;
+                if (sentDates.containsKey(instance.getLastStatusChangeDate())) {
+                    Integer count = sentDates.get(instance.getLastStatusChangeDate());
+                    sentDates.put(instance.getLastStatusChangeDate(), count + 1);
+                } else {
+                    sentDates.put(instance.getLastStatusChangeDate(), 1);
+                }
             }
         }
 
         transferCursor = transferDao.getReceiveInstancesCursor();
         transferInstances = transferDao.getInstancesFromCursor(transferCursor);
         int receiveCount = 0;
+        HashMap<Long, Integer> receiveDates = new HashMap<>();
         for (TransferInstance instance : transferInstances) {
             if (instanceMap.containsKey(instance.getInstanceId())) {
                 receiveCount++;
+                if (receiveDates.containsKey(instance.getLastStatusChangeDate())) {
+                    Integer count = receiveDates.get(instance.getLastStatusChangeDate());
+                    receiveDates.put(instance.getLastStatusChangeDate(), count + 1);
+                } else {
+                    receiveDates.put(instance.getLastStatusChangeDate(), 1);
+                }
             }
         }
 
         transferCursor = transferDao.getReviewedInstancesCursor();
         transferInstances = transferDao.getInstancesFromCursor(transferCursor);
         int reviewCount = 0;
+        HashMap<Long, Integer> reviewDates = new HashMap<>();
         for (TransferInstance instance : transferInstances) {
             if (instanceMap.containsKey(instance.getInstanceId())) {
                 reviewCount++;
+                if (reviewDates.containsKey(instance.getLastStatusChangeDate())) {
+                    Integer count = reviewDates.get(instance.getLastStatusChangeDate());
+                    reviewDates.put(instance.getLastStatusChangeDate(), count + 1);
+                } else {
+                    reviewDates.put(instance.getLastStatusChangeDate(), 1);
+                }
             }
         }
+
         drawGraph(sentCount, receiveCount, reviewCount);
+        drawGraph(sentDates, receiveDates, reviewDates);
         super.onResume();
     }
 
@@ -186,5 +226,121 @@ public class StatisticsFragment extends InjectableFragment {
         chart.setTouchEnabled(false);
         chart.setDescription(null);
         chart.invalidate(); // refresh
+    }
+
+    public void drawGraph(HashMap<Long, Integer> sentDates, HashMap<Long, Integer> receiveDates, HashMap<Long, Integer> reviewDates) {
+        List<Entry> sentEntries = new ArrayList<>();
+        List<Entry> receiveEntries = new ArrayList<>();
+        List<Entry> reviewEntries = new ArrayList<>();
+        DateFormat df = new SimpleDateFormat("dd:MM");
+        int maxValue = 0;
+        HashSet<Long> uniqueDates = new HashSet<>();
+
+        Iterator sentDatesIterator = sentDates.entrySet().iterator();
+        while(sentDatesIterator.hasNext()) {
+            Map.Entry date = (Map.Entry)sentDatesIterator.next();
+            sentEntries.add(new Entry((Long)date.getKey(), (Integer)date.getValue()));
+            maxValue = (Integer)date.getValue() > maxValue ? (Integer)date.getValue():maxValue;
+            uniqueDates.add((Long)date.getKey());
+        }
+        if (sentEntries.isEmpty()) {
+           sentEntries.add(new Entry(0, 0));
+        }
+        Iterator receiveDatesIterator = receiveDates.entrySet().iterator();
+        while(receiveDatesIterator.hasNext()) {
+            Map.Entry date = (Map.Entry)receiveDatesIterator.next();
+            receiveEntries.add(new Entry((Long)date.getKey(), (Integer)date.getValue()));
+            maxValue = (Integer)date.getValue() > maxValue ? (Integer)date.getValue():maxValue;
+            uniqueDates.add((Long)date.getKey());
+        }
+        if (receiveEntries.isEmpty()) {
+            receiveEntries.add(new Entry(0, 0));
+        }
+
+        Iterator reviewDatesIterator = reviewDates.entrySet().iterator();
+        while (reviewDatesIterator.hasNext()) {
+            Map.Entry date = (Map.Entry)reviewDatesIterator.next();
+            reviewEntries.add(new Entry((Long)date.getKey(), (Integer)date.getValue()));
+            maxValue = (Integer)date.getValue() > maxValue ? (Integer)date.getValue():maxValue;
+            uniqueDates.add((Long)date.getKey());
+        }
+        if (reviewEntries.isEmpty()) {
+            reviewEntries.add(new Entry(0 , 0));
+        }
+
+        ScatterDataSet sentSet = new ScatterDataSet(sentEntries, "Sent");
+        sentSet.setScatterShape(ScatterChart.ScatterShape.SQUARE);
+        sentSet.setColor(ColorTemplate.COLORFUL_COLORS[0]);
+
+        ScatterDataSet receiveSet = new ScatterDataSet(receiveEntries, "Received");
+        receiveSet.setScatterShape(ScatterChart.ScatterShape.TRIANGLE);
+        receiveSet.setColor(ColorTemplate.COLORFUL_COLORS[1]);
+
+        ScatterDataSet reviewSet = new ScatterDataSet(reviewEntries, "Reviewed");
+        reviewSet.setScatterShape(ScatterChart.ScatterShape.CROSS);
+        reviewSet.setColor(ColorTemplate.COLORFUL_COLORS[2]);
+
+        sentSet.setScatterShapeSize(8f);
+        receiveSet.setScatterShapeSize(8f);
+        reviewSet.setScatterShapeSize(8f);
+
+        XAxis axisX = detail_chart.getXAxis();
+        YAxis axisYR = detail_chart.getAxisRight();
+        YAxis axisYL = detail_chart.getAxisLeft();
+        axisYL.setTypeface(Typeface.DEFAULT_BOLD);
+        axisX.setPosition(XAxis.XAxisPosition.BOTTOM);
+        axisYR.setEnabled(false);
+        axisX.setDrawGridLines(false);
+        axisYR.setDrawGridLines(false);
+        axisX.setDrawLabels(true);
+        axisX.setTypeface(Typeface.DEFAULT_BOLD);
+        axisYL.setAxisMinimum(0);
+        axisYL.setValueFormatter(new LargeValueFormatter());
+        axisX.setAxisMinimum(0);
+        int granularity = 1;
+        if (maxValue <= 5) {
+            axisYL.setAxisMaximum(5);
+        } else {
+            int axisMax;
+            maxValue += 1;
+            if (maxValue % 5 != 0) {
+                granularity = (maxValue / 5) + 1;
+                axisMax = 5 * granularity;
+            } else {
+                axisMax = maxValue;
+                granularity = maxValue / 5;
+            }
+            axisYL.setAxisMaximum(axisMax);
+        }
+        axisYL.setGranularity(granularity);
+        axisX.setLabelCount(uniqueDates.size(), true);
+        axisYL.setLabelCount(6, true);
+
+        axisX.setValueFormatter(new IAxisValueFormatter() {
+            @Override
+            public String getFormattedValue(float value, AxisBase axis) {
+                if (value > 0) {
+                    return df.format(new Date((long)value));
+                }
+                return "";
+            }
+        });
+
+
+        ArrayList<IScatterDataSet> dataSets = new ArrayList<>();
+        dataSets.add(sentSet); // add the data sets
+        dataSets.add(receiveSet);
+        dataSets.add(reviewSet);
+
+        // create a data object with the data sets
+        ScatterData data = new ScatterData(dataSets);
+        //data.setValueTypeface(tfLight);
+
+        detail_chart.setData(data);
+        detail_chart.setDoubleTapToZoomEnabled(false);
+        detail_chart.setPinchZoom(false);
+        detail_chart.setDescription(null);
+        detail_chart.setHorizontalScrollBarEnabled(true);
+        detail_chart.invalidate();
     }
 }

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/PreferenceKeys.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/PreferenceKeys.java
@@ -13,6 +13,7 @@ public class PreferenceKeys {
     public static final String KEY_DEFAULT_TRANSFER_METHOD = "default_transfer_method";
     public static final String KEY_BLUETOOTH_NAME = "bluetooth_name";
     public static final String KEY_BLUETOOTH_SECURE_MODE = "bluetooth_secure_mode";
+    public static final String KEY_DETAILED_STATISTICS = "detailed_statistics";
 
     private PreferenceKeys() {
 

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/SettingsActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/SettingsActivity.java
@@ -41,6 +41,7 @@ public class SettingsActivity extends PreferenceActivity {
     Preference hotspotPasswordPreference;
     CheckBoxPreference passwordRequirePreference;
     CheckBoxPreference btSecureModePreference;
+    CheckBoxPreference statisticsPreference;
     EditTextPreference odkDestinationDirPreference;
     ListPreference defaultMethodPreference;
     private SharedPreferences prefs;
@@ -75,6 +76,7 @@ public class SettingsActivity extends PreferenceActivity {
         passwordRequirePreference = (CheckBoxPreference) findPreference(PreferenceKeys.KEY_HOTSPOT_PWD_REQUIRE);
         btSecureModePreference = (CheckBoxPreference) findPreference(PreferenceKeys.KEY_BLUETOOTH_SECURE_MODE);
         odkDestinationDirPreference = (EditTextPreference) findPreference(PreferenceKeys.KEY_ODK_DESTINATION_DIR);
+        statisticsPreference = (CheckBoxPreference) findPreference(PreferenceKeys.KEY_DETAILED_STATISTICS);
 
         prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
 
@@ -89,11 +91,12 @@ public class SettingsActivity extends PreferenceActivity {
         boolean isPasswordSet = prefs.getBoolean(PreferenceKeys.KEY_HOTSPOT_PWD_REQUIRE, false);
         odkDestinationDirPreference.setSummary(prefs.getString(PreferenceKeys.KEY_ODK_DESTINATION_DIR,
                 getString(R.string.default_odk_destination_dir)));
-        boolean isSecureMode = prefs.getBoolean(PreferenceKeys.KEY_BLUETOOTH_SECURE_MODE, true);
-
         hotspotPasswordPreference.setEnabled(isPasswordSet);
         passwordRequirePreference.setChecked(isPasswordSet);
+        boolean isSecureMode = prefs.getBoolean(PreferenceKeys.KEY_BLUETOOTH_SECURE_MODE, true);
         btSecureModePreference.setChecked(isSecureMode);
+        boolean detailedStatisticsEnabled = prefs.getBoolean(PreferenceKeys.KEY_DETAILED_STATISTICS, false);
+        statisticsPreference.setChecked(detailedStatisticsEnabled);
 
         hotspotNamePreference.setOnPreferenceChangeListener(preferenceChangeListener());
         bluetoothNamePreference.setOnPreferenceChangeListener(preferenceChangeListener());

--- a/skunkworks_crow/src/main/res/drawable/ic_show_chart_black_24dp.xml
+++ b/skunkworks_crow/src/main/res/drawable/ic_show_chart_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3.5,18.49l6,-6.01 4,4L22,6.92l-1.41,-1.41 -7.09,7.97 -4,-4L2,16.99z"/>
+</vector>

--- a/skunkworks_crow/src/main/res/layout/fragment_stats.xml
+++ b/skunkworks_crow/src/main/res/layout/fragment_stats.xml
@@ -36,6 +36,12 @@
             android:layout_height="184dp"
             android:layout_gravity="center" />
 
+        <com.github.mikephil.charting.charts.ScatterChart
+            android:id="@+id/detailed_chart"
+            android:layout_width="362dp"
+            android:layout_height="184dp"
+            android:layout_gravity="center" />
+
         <View
             style="@style/MatchParentWidth"
             android:layout_weight="1.0" />

--- a/skunkworks_crow/src/main/res/xml/preferences_menu.xml
+++ b/skunkworks_crow/src/main/res/xml/preferences_menu.xml
@@ -18,6 +18,12 @@
             android:summary="@string/preference_default_method_summary"
             android:title="@string/preference_default_method" />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:icon="@drawable/ic_show_chart_black_24dp"
+            android:key="detailed_statistics"
+            android:title="Show Detailed Statistics" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Hotspot Settings">


### PR DESCRIPTION
Closes #178 

#### What has been done to verify that this works as intended?
Tested on Android 9, sending and receiving different forms.
Screenshots:
![Screenshot_20200123-203744](https://user-images.githubusercontent.com/47722139/73006746-24cdad00-3e31-11ea-8344-0f34a611848c.jpg)
![Screenshot_20200123-222841](https://user-images.githubusercontent.com/47722139/73006751-26977080-3e31-11ea-9156-b710e8294078.jpg)


#### Why is this the best possible solution? Were any other approaches considered?
This is a minimalistic graph, which does not bloat the screen too much at the same time conveying the required information.
I've chosen to show past 30 days activity, no more than that, because 
1. I believe Statistics are less relevant after a month
2. On portrait view, we have to minimize the dates we can show.(Currently only the current week is visible and user would have to swipe left on xAxis to see more.)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users who want a more detailed statistics of the forms, would have to select Show Detailed Statistics checkbox in General Settings, the scatter chart is programmed to show past 30 days activity of that instance.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).