### PR TITLE
Fixes Issue#352: No adapter attached; Skipping layout in BlankFormsFragment and FilledFormsFragment

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/instance/adapter/InstanceAdapter.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/instance/adapter/InstanceAdapter.java
@@ -101,7 +101,9 @@ public class InstanceAdapter extends RecyclerView.Adapter<InstanceAdapter.Instan
 
     @Override
     public int getItemCount() {
-        if (cursor == null) return 0;
+        if (cursor == null) {
+            return 0;
+        }
         return !cursor.isClosed() ? cursor.getCount() : 0;
     }
 

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/instance/adapter/InstanceAdapter.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/instance/adapter/InstanceAdapter.java
@@ -101,13 +101,16 @@ public class InstanceAdapter extends RecyclerView.Adapter<InstanceAdapter.Instan
 
     @Override
     public int getItemCount() {
+        if (cursor == null) return 0;
         return !cursor.isClosed() ? cursor.getCount() : 0;
     }
 
-
-
     public Cursor getCursor() {
         return cursor;
+    }
+
+    public void setCursor(Cursor cursor) {
+        this.cursor = cursor;
     }
 
     public interface OnItemClickListener {

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/BlankFormsFragment.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/BlankFormsFragment.java
@@ -125,9 +125,7 @@ public class BlankFormsFragment extends FormListFragment implements LoaderManage
 
 
     @Override
-    public void onLoaderReset(@NonNull Loader loader) {
-        formAdapter.swapCursor(null);
-    }
+    public void onLoaderReset(@NonNull Loader loader) { }
 
     @Override
     public void onItemClick(BaseCursorViewHolder holder, int position) {

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/BlankFormsFragment.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/BlankFormsFragment.java
@@ -101,6 +101,8 @@ public class BlankFormsFragment extends FormListFragment implements LoaderManage
     @NonNull
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+        formAdapter = new FormsAdapter(getActivity(), null, this, selectedForms, instancesDao, transferDao);
+        recyclerView.setAdapter(formAdapter);
         return formsDao.getFormsCursorLoader(getFilterText(), getSortingOrder());
     }
 
@@ -108,8 +110,7 @@ public class BlankFormsFragment extends FormListFragment implements LoaderManage
     public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
         if (cursor != null) {
             cursor.moveToFirst();
-            formAdapter = new FormsAdapter(getActivity(), cursor, this, selectedForms, instancesDao, transferDao);
-            recyclerView.setAdapter(formAdapter);
+            formAdapter.swapCursor(cursor);
             setEmptyViewVisibility(cursor.getCount());
             if (formAdapter.getItemCount() > 0) {
                 toggleButton.setText(getString(R.string.select_all));
@@ -124,7 +125,9 @@ public class BlankFormsFragment extends FormListFragment implements LoaderManage
 
 
     @Override
-    public void onLoaderReset(@NonNull Loader loader) { }
+    public void onLoaderReset(@NonNull Loader loader) {
+        formAdapter.swapCursor(null);
+    }
 
     @Override
     public void onItemClick(BaseCursorViewHolder holder, int position) {

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/BlankFormsFragment.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/BlankFormsFragment.java
@@ -125,7 +125,9 @@ public class BlankFormsFragment extends FormListFragment implements LoaderManage
 
 
     @Override
-    public void onLoaderReset(@NonNull Loader loader) { }
+    public void onLoaderReset(@NonNull Loader loader) {
+        formAdapter.swapCursor(null);
+    }
 
     @Override
     public void onItemClick(BaseCursorViewHolder holder, int position) {

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/FilledFormsFragment.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/FilledFormsFragment.java
@@ -114,7 +114,9 @@ public class FilledFormsFragment extends InstanceListFragment implements LoaderM
     }
 
     @Override
-    public void onLoaderReset(@NonNull Loader loader) { }
+    public void onLoaderReset(@NonNull Loader loader) {
+        instanceAdapter.setCursor(null);
+    }
 
     private void onListItemClick(View view, int position) {
         Cursor cursor = instanceAdapter.getCursor();

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/FilledFormsFragment.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/FilledFormsFragment.java
@@ -114,9 +114,7 @@ public class FilledFormsFragment extends InstanceListFragment implements LoaderM
     }
 
     @Override
-    public void onLoaderReset(@NonNull Loader loader) {
-        instanceAdapter.setCursor(null);
-    }
+    public void onLoaderReset(@NonNull Loader loader) { }
 
     private void onListItemClick(View view, int position) {
         Cursor cursor = instanceAdapter.getCursor();

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/FilledFormsFragment.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/send/fragment/FilledFormsFragment.java
@@ -91,6 +91,8 @@ public class FilledFormsFragment extends InstanceListFragment implements LoaderM
     @NonNull
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+        instanceAdapter = new InstanceAdapter(getActivity(), null, this::onListItemClick, selectedInstances);
+        recyclerView.setAdapter(instanceAdapter);
         return instancesDao.getSavedInstancesCursorLoader(getFilterText(), getSortingOrder());
     }
 
@@ -98,8 +100,7 @@ public class FilledFormsFragment extends InstanceListFragment implements LoaderM
     public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
         if (cursor != null) {
             cursor.moveToFirst();
-            instanceAdapter = new InstanceAdapter(getActivity(), cursor, this::onListItemClick, selectedInstances);
-            recyclerView.setAdapter(instanceAdapter);
+            instanceAdapter.setCursor(cursor);
             setEmptyViewVisibility(cursor.getCount());
             if (instanceAdapter.getItemCount() > 0) {
                 toggleButton.setText(getString(R.string.select_all));
@@ -112,9 +113,10 @@ public class FilledFormsFragment extends InstanceListFragment implements LoaderM
         }
     }
 
-
     @Override
-    public void onLoaderReset(@NonNull Loader loader) { }
+    public void onLoaderReset(@NonNull Loader loader) {
+        instanceAdapter.setCursor(null);
+    }
 
     private void onListItemClick(View view, int position) {
         Cursor cursor = instanceAdapter.getCursor();


### PR DESCRIPTION
Closes #352 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I tested it on Android 9.0.

**Android Studio Logcat on new branch:**
![logcat-skipping-layout-debug](https://user-images.githubusercontent.com/35730054/73682761-0ac08400-46e7-11ea-8df3-7088690e7208.png)

**Android Studio Logcat on master branch:**
![ogcat-skipping-layout-before](https://user-images.githubusercontent.com/35730054/73682765-0c8a4780-46e7-11ea-9ecc-07bd2f6ddcf0.png)


#### Why is this the best possible solution? Were any other approaches considered?
I found that the `instanceAdapter` and `formAdapter` was getting attached in the `onLoadFinished` method, which is sometimes delayed. I followed the documentation at Android developers, [here](https://developer.android.com/guide/components/loaders), and found that it is better to attach the adapter in the `onCreateLoader` method, and update the cursor, later on, in `onLoadFinished` method. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I don't think there are any regression risks, as of now. 

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).