### PR TITLE
fix: MainActivity UI is updating after updating in database

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
@@ -110,7 +110,6 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
     @Override
     public void onResume() {
         super.onResume();
-        //update the list
         if (formAdapter != null) {
             formAdapter.notifyDataSetChanged();
         }

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
@@ -107,6 +107,15 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
         addListItemDivider();
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        //update the list
+        if (formAdapter != null) {
+            formAdapter.notifyDataSetChanged();
+        }
+    }
+
     private void setupAdapter() {
         formAdapter = new FormsAdapter(this, null, this, instancesDao, transferDao);
         recyclerView.setAdapter(formAdapter);


### PR DESCRIPTION
Closes #309 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
- Checked whether `reviewed` and `unreviewed` count is getting perfectly or not 
- Checked whether the count is updating when on pressing the back button 
- Checked whether any new warnings are produced by adding this code
- Checked any tests are failing
- Checked by changing the orientation of the device

#### Why is this the best possible solution? Were any other approaches considered?
Removed previous approach of the query(checking every time status of form) and added the query for getting `receivedCount` and `reviewedCount` so, we can get the unReviewed count with `receivedCount-reviewedCount` and Updated the forms adapter when user presses back button from another activity in `onResume`

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

By updating the UI in `onResume` so, the user no need to restart the activity and get the change 

#### GIF
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/48018942/73759123-7828ef00-4791-11ea-97ac-e5ba98c799ae.gif)


#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).