### PR TITLE
crash: Crashing on sending Forms through hotspot #323

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/network/WifiHospotConnector.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/network/WifiHospotConnector.java
@@ -75,9 +75,9 @@ public class WifiHospotConnector {
     }
 
     public WifiConfiguration getWifiConfig() {
-        Object obj = null;
+        Object obj;
         try {
-            obj = getWifiApConfig.invoke(wifiManager, obj);
+            obj = getWifiApConfig.invoke(wifiManager);
             if (obj != null) {
                 return (WifiConfiguration) obj;
             }


### PR DESCRIPTION
Remove null object being passed to invoke() method

Closes #

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I tried to reproduce the problem after making the changes. The crashing has stopped.
#### Why is this the best possible solution? Were any other approaches considered?
The null object being passed was redundant. No.
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The crashing will stop.
#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).