### PR TITLE
Fixes Issue#370: Used DialogFragment to retain Set Hotspot Password Dialog on screen rotation

### DIFF
--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/SetHotspotPasswordDialog.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/SetHotspotPasswordDialog.java
@@ -26,11 +26,9 @@ public class SetHotspotPasswordDialog extends DialogFragment {
     private View dialogView;
     private TextInputLayout tlPassword;
     private TextInputEditText edtpass;
-    private String npass;
 
     public static SetHotspotPasswordDialog newInstance() {
-        SetHotspotPasswordDialog setHotspotPasswordDialog = new SetHotspotPasswordDialog();
-        return setHotspotPasswordDialog;
+        return new SetHotspotPasswordDialog();
     }
 
     @Override
@@ -57,7 +55,6 @@ public class SetHotspotPasswordDialog extends DialogFragment {
         if (alertDialog == null) {
 
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-            npass = prefs.getString(PreferenceKeys.KEY_HOTSPOT_PASSWORD, getString(R.string.default_hotspot_password));
 
             builder.setTitle(getString(R.string.title_hotspot_password));
             builder.setView(dialogView);
@@ -81,6 +78,7 @@ public class SetHotspotPasswordDialog extends DialogFragment {
                         public void beforeTextChanged(CharSequence s, int start, int count, int after) {
 
                         }
+
                         @Override
                         public void onTextChanged(CharSequence s, int start, int before, int count) {
                             if (edtpass.getText().toString().length() >= 8) {

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/SetHotspotPasswordDialog.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/SetHotspotPasswordDialog.java
@@ -1,0 +1,116 @@
+package org.odk.share.views.ui.settings;
+
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.WindowManager;
+
+import androidx.appcompat.app.AlertDialog;
+
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
+
+import org.odk.share.R;
+
+public class SetHotspotPasswordDialog extends DialogFragment {
+
+    private SharedPreferences prefs;
+    private View dialogView;
+    private TextInputLayout tlPassword;
+    private TextInputEditText edtpass;
+    private String npass;
+
+    public static SetHotspotPasswordDialog newInstance() {
+        SetHotspotPasswordDialog setHotspotPasswordDialog = new SetHotspotPasswordDialog();
+        return setHotspotPasswordDialog;
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+
+        prefs = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
+
+        LayoutInflater factory = LayoutInflater.from(context);
+        dialogView = factory.inflate(R.layout.dialog_password_til, null);
+
+        tlPassword = dialogView.findViewById(R.id.et_password_layout);
+        tlPassword.getEditText().setText(prefs.getString(PreferenceKeys.KEY_HOTSPOT_PASSWORD, getString(R.string.default_hotspot_password)));
+        edtpass = (TextInputEditText) dialogView.findViewById(R.id.edtpass);
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreateDialog(savedInstanceState);
+        setRetainInstance(true);
+
+        AlertDialog alertDialog = (AlertDialog) getDialog();
+
+        if (alertDialog == null) {
+
+            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+            npass = prefs.getString(PreferenceKeys.KEY_HOTSPOT_PASSWORD, getString(R.string.default_hotspot_password));
+
+            builder.setTitle(getString(R.string.title_hotspot_password));
+            builder.setView(dialogView);
+            builder.setPositiveButton(getString(R.string.ok), (dialog, which) -> {
+
+                ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+
+                String password = tlPassword.getEditText().getText().toString();
+                prefs.edit().putString(PreferenceKeys.KEY_HOTSPOT_PASSWORD, password).apply();
+            });
+            builder.setNegativeButton(getString(R.string.cancel), (dialog, which) -> dialog.dismiss());
+
+            builder.setCancelable(false);
+            alertDialog = builder.create();
+
+            alertDialog.setOnShowListener(new DialogInterface.OnShowListener() {
+                @Override
+                public void onShow(DialogInterface dialog) {
+                    edtpass.addTextChangedListener(new TextWatcher() {
+                        @Override
+                        public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+                        }
+                        @Override
+                        public void onTextChanged(CharSequence s, int start, int before, int count) {
+                            if (edtpass.getText().toString().length() >= 8) {
+                                ((AlertDialog) dialog) .getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                            } else {
+                                ((AlertDialog) dialog) .getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                            }
+                        }
+
+                        @Override
+                        public void afterTextChanged(Editable s) {
+
+                        }
+                    });
+                }
+            });
+            alertDialog.setCancelable(true);
+            alertDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+        }
+
+        return alertDialog;
+    }
+
+    @Override
+    public void onDestroyView() {
+        AlertDialog dialog = (AlertDialog) getDialog();
+        if (dialog != null && getRetainInstance()) {
+            dialog.setDismissMessage(null);
+            dialog.dismiss();
+        }
+        super.onDestroyView();
+    }
+}

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/SettingsActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/SettingsActivity.java
@@ -108,7 +108,8 @@ public class SettingsActivity extends PreferenceActivity {
         return preference -> {
             switch (preference.getKey()) {
                 case PreferenceKeys.KEY_HOTSPOT_PASSWORD:
-                    showPasswordDialog();
+                    SetHotspotPasswordDialog setHotspotPasswordDialog = SetHotspotPasswordDialog.newInstance();
+                    setHotspotPasswordDialog.show(getFragmentManager(), "set hotspot password dialog");
                     break;
             }
             return false;
@@ -180,70 +181,5 @@ public class SettingsActivity extends PreferenceActivity {
             return (ViewGroup) findViewById(android.R.id.list).getParent();
         }
     }
-
-    private void showPasswordDialog() {
-        LayoutInflater factory = LayoutInflater.from(this);
-
-        View dialogView = factory.inflate(R.layout.dialog_password_til, null);
-
-        TextInputLayout tlPassword = dialogView.findViewById(R.id.et_password_layout);
-        tlPassword.getEditText().setText(prefs.getString(PreferenceKeys.KEY_HOTSPOT_PASSWORD, getString(R.string.default_hotspot_password)));
-
-        edtpass = (TextInputEditText) dialogView.findViewById(R.id.edtpass);
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        npass = prefs.getString(PreferenceKeys.KEY_HOTSPOT_PASSWORD, getString(R.string.default_hotspot_password));
-
-        builder.setTitle(getString(R.string.title_hotspot_password));
-        builder.setView(dialogView);
-        builder.setPositiveButton(getString(R.string.ok), (dialog, which) -> {
-
-
-            ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
-
-            String password = tlPassword.getEditText().getText().toString();
-            prefs.edit().putString(PreferenceKeys.KEY_HOTSPOT_PASSWORD, password).apply();
-        });
-        builder.setNegativeButton(getString(R.string.cancel), (dialog, which) -> dialog.dismiss());
-
-        builder.setCancelable(false);
-        AlertDialog alertDialog = builder.create();
-
-        alertDialog.setOnShowListener(new DialogInterface.OnShowListener() {
-
-            @Override
-            public void onShow(DialogInterface dialog) {
-
-                edtpass.addTextChangedListener(new TextWatcher() {
-                    @Override
-                    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-                 
-                    }
-
-                    @Override
-                    public void onTextChanged(CharSequence s, int start, int before, int count) {
-
-                        if (edtpass.getText().toString().length() >= 8) {
-                            ((AlertDialog) dialog) .getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
-                        } else {
-                            ((AlertDialog) dialog) .getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
-                        }
-                    }
-
-                    @Override
-                    public void afterTextChanged(Editable s) {
-
-                    }
-                });
-            }
-        });
-
-
-        alertDialog.show();
-
-        alertDialog.setCancelable(true);
-        alertDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
-    }
-
 }
 

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/SettingsActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/settings/SettingsActivity.java
@@ -1,7 +1,6 @@
 package org.odk.share.views.ui.settings;
 
 import android.bluetooth.BluetoothAdapter;
-import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
@@ -11,21 +10,13 @@ import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
-import android.text.Editable;
 import android.text.TextUtils;
-import android.text.TextWatcher;
-import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowManager;
 import android.widget.Toast;
 
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
-
-import com.google.android.material.textfield.TextInputEditText;
-import com.google.android.material.textfield.TextInputLayout;
 
 import org.odk.share.R;
 
@@ -43,8 +34,6 @@ public class SettingsActivity extends PreferenceActivity {
     EditTextPreference odkDestinationDirPreference;
     ListPreference defaultMethodPreference;
     private SharedPreferences prefs;
-    String npass;
-    TextInputEditText edtpass;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
Closes #370 

<!-- 
Thank you for contributing to ODK!
-->

#### What has been done to verify that this works as intended?
I tested it on Android 9.0.

#### Why is this the best possible solution? Were any other approaches considered?
I used transfered Alert Dialog inside Dialog Fragment to retain it when sreen undergoes orientation change.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risks.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).