### PR TITLE
Fix: Add Toast "Press BACK to exit" for exit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 28 17:15:18 IST 2019
+#Mon Mar 16 16:33:49 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
+++ b/skunkworks_crow/src/main/java/org/odk/share/views/ui/main/MainActivity.java
@@ -9,6 +9,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -61,6 +62,7 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
     private static final String COLLECT_PACKAGE = "org.odk.collect.android";
     private static final int STORAGE_PERMISSION_REQUEST_CODE = 101;
     private static final int FORM_LOADER = 2;
+    private static boolean BACK_FLAG = false;
 
     @BindView(R.id.toolbar)
     Toolbar toolbar;
@@ -291,5 +293,23 @@ public class MainActivity extends FormListActivity implements LoaderManager.Load
                 showAlertDialog();
             }
         }
+    }
+
+    // Add toast "Press BACK to exit"
+    @Override
+    public void onBackPressed() {
+        if(BACK_FLAG){
+            super.onBackPressed();
+            return;
+        }
+        BACK_FLAG = true;
+        Toast.makeText(getApplicationContext(),"Press BACK to exit",Toast.LENGTH_SHORT).show();
+
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                BACK_FLAG = false;
+            }
+        },2000);
     }
 }


### PR DESCRIPTION
Closes #372 

#### What has been done to verify that this works as intended?

I tested it on Android 9.0.

#### Why is this the best possible solution? Were any other approaches considered?

As comments in this issue, I figure out that exit confirmation is good, but not by dialog so I'm doing this by an easy approach.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No regression risks

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkCode` and confirmed all checks still pass OR confirm CircleCI build passes
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/share/blob/master/share_app/src/main/assets/open_source_licenses.html).